### PR TITLE
Fix #330 - video-speed and video-reverse always keep audio stream

### DIFF
--- a/mediatools/reverse.py
+++ b/mediatools/reverse.py
@@ -19,24 +19,18 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-import argparse
 import mediatools.utilities as util
 import mediatools.options as opt
 import mediatools.videofile as video
 
 
 def main():
-    util.init("video-reverse")
-    parser = argparse.ArgumentParser(description="Reverse a video")
-    parser.add_argument("-i", "--inputfiles", help="Video file to reverse", required=True)
-    parser.add_argument("-o", "--outputfile", help="Output file to generate", required=False)
-    parser.add_argument("-g", "--debug", required=False, type=int, help="Debug level")
+    parser = util.get_common_args("video-reverse", "Reverse a video")
     parser.add_argument(
         "-k", "--keep_audio", required=False, dest=opt.Option.MUTE, action="store_false", default=True, help="Keep audio track after reverse"
     )
-    parser.add_argument("--hw_accel", required=False, dest="hw_accel", action="store_true", default=False, help="Enable hardware (GPU) acceleration")
     kwargs = util.parse_media_args(parser)
-    output = video.reverse(kwargs.pop("inputfiles")[0], kwargs.get("outputfile", None), **kwargs)
+    output = video.reverse(kwargs.pop("inputfiles")[0], kwargs.pop("outputfile", None), **kwargs)
     util.generated_file(output)
 
 

--- a/mediatools/videofile.py
+++ b/mediatools/videofile.py
@@ -696,9 +696,9 @@ def slideshow(*inputs, resolution=None):
         return (concat(target_file=final_file, file_list=slideshows, with_audio=False), operations)
 
 
-def speed(filename, target_speed, output=None, **kwargs):
+def speed(filename, target_speed, output=None, mute=True, **kwargs):
     output = util.automatic_output_file_name(outfile=output, infile=filename, postfix=f"speed-{target_speed}")
-    return VideoFile(filename).encode(speed=target_speed, target_file=output, **kwargs)
+    return VideoFile(filename).encode(speed=target_speed, target_file=output, mute=mute, **kwargs)
 
 
 def volume(filename, vol, output=None, **kwargs):
@@ -706,10 +706,10 @@ def volume(filename, vol, output=None, **kwargs):
     return VideoFile(filename).encode(volume=vol, target_file=output, **kwargs)
 
 
-def reverse(filename, output=None, **kwargs):
+def reverse(filename, output=None, mute=True, **kwargs):
     kwargs["hw_accel"] = False  # Reverse filter not compatible with HW accel
     output = util.automatic_output_file_name(outfile=output, infile=filename, postfix="reverse")
-    return VideoFile(filename).encode(reverse=True, target_file=output, **kwargs)
+    return VideoFile(filename).encode(reverse=True, target_file=output, mute=mute, **kwargs)
 
 
 def deshake(filename, output=None, **kwargs):

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -93,3 +93,15 @@ def test_main_no_file():
             assert False
         except SystemExit as e:
             assert int(str(e)) == 2
+
+
+def test_reverse_api_removes_audio():
+    output = video.reverse(VIDEO, output=TMP1)
+    assert video.VideoFile(output).audio_codec is None
+    os.remove(output)
+
+
+def test_reverse_api_keep_audio():
+    output = video.reverse(VIDEO, output=TMP1, mute=False)
+    assert video.VideoFile(output).audio_codec is not None
+    os.remove(output)

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -96,3 +96,15 @@ def test_bad_speed():
             assert False
         except SystemExit as e:
             assert int(str(e)) == 1
+
+
+def test_speed_api_removes_audio():
+    output = video.speed(VIDEO, "2", output=TMP1)
+    assert video.VideoFile(output).audio_codec is None
+    os.remove(output)
+
+
+def test_speed_api_keep_audio():
+    output = video.speed(VIDEO, "2", output=TMP1, mute=False)
+    assert video.VideoFile(output).audio_codec is not None
+    os.remove(output)


### PR DESCRIPTION
## Summary

- **`reverse.py`**: Refactored to use `util.get_common_args()` (consistent with `speed.py`). The previous bare `ArgumentParser` lacked `nargs="+"` on `-i/--inputfiles`, causing `kwargs.pop("inputfiles")[0]` to return the first *character* of the filename instead of the first file — breaking the tool entirely.
- **`videofile.py`**: Added `mute=True` default to `speed()` and `reverse()` so audio is removed when called programmatically, consistent with the CLI default behavior.
- **Tests**: Added `test_speed_api_removes_audio`, `test_speed_api_keep_audio`, `test_reverse_api_removes_audio`, `test_reverse_api_keep_audio` to cover API-level audio removal and the `mute=False` override.

Closes #330

## Test plan

- [ ] `pytest tests/test_reverse.py` — all 8 tests pass
- [ ] `pytest tests/test_speed.py` — new API tests pass
- [ ] `video.speed("file.mp4", "2x")` produces output with no audio track
- [ ] `video.reverse("file.mp4")` produces output with no audio track
- [ ] Both functions accept `mute=False` to keep audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)