### PR TITLE
Fix #362 - Update deprecated SonarCloud GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: SonarCloud scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -87,7 +87,7 @@ jobs:
 
   #   steps:
   #   - name: Checkout repository
-  #     uses: actions/checkout@v2
+  #     uses: actions/checkout@v4
 
   #   # Initializes the CodeQL tools for scanning.
   #   - name: Initialize CodeQL


### PR DESCRIPTION
## Summary

- Replace deprecated `SonarSource/sonarcloud-github-action@master` with `SonarSource/sonarqube-scan-action@master`, aligned with the working reference in [sonar-tools](https://github.com/okorach/sonar-tools/blob/master/.github/workflows/build.yml)
- Update stale `actions/checkout@v2` → `@v4` in the commented-out CodeQL section

Closes #362

## Test plan

- [ ] Build pipeline triggers on next push/PR and completes successfully
- [ ] SonarQube Cloud scan step runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)