### PR TITLE
video-concat: add GPU (CUDA) acceleration support

### DIFF
--- a/mediatools/concat.py
+++ b/mediatools/concat.py
@@ -31,10 +31,11 @@ def main():
     util.init("video-concat")
     parser = argparse.ArgumentParser(description="Concatenates several videos")
     parser.add_argument("-i", "--inputfiles", nargs="+", help="List of files to concatenate", required=True)
-    parser.add_argument("-o", "--outputfile", help="Output file to generate", required=False)
+    parser.add_argument("-o", "--outputfile", help="Output file to generate", required=True)
     parser.add_argument("-g", "--debug", required=False, type=int, help="Debug level")
+    parser.add_argument("--hw_accel", required=False, choices=["auto", "off", "on"], help="Use Nvidia HW acceleration")
     kwargs = util.parse_media_args(parser)
-    output = video.concat(kwargs.get("outputfile", None), kwargs.pop("inputfiles"))
+    output = video.concat(kwargs.get("outputfile"), kwargs.pop("inputfiles"), hw_accel=kwargs.get("hw_accel", False))
     util.generated_file(output)
 
 

--- a/mediatools/videofile.py
+++ b/mediatools/videofile.py
@@ -530,7 +530,7 @@ def get_crop_filter_options(width: int, height: int, top: int, left: int) -> str
     return "-filter:v crop={0}:{1}:{2}:{3}".format(width, height, top, left)
 
 
-def concat(target_file: str, file_list: list[str], with_audio: bool = True) -> str:
+def concat(target_file: str, file_list: list[str], with_audio: bool = True, hw_accel: bool = False) -> str:
     """Concatenates several video files - They must have same video+audio format and bitrate"""
     file_list = sorted(file_list, key=lambda f: os.path.basename(f).lower())
     log.logger.info("%s = %s", target_file, " + ".join(file_list))
@@ -551,9 +551,17 @@ def concat(target_file: str, file_list: list[str], with_audio: bool = True) -> s
 
     mapping = '-map "[outv]"' + "".join(f' -map "[outa{j}]"' for j in range(n_audio))
 
-    files_str = filters.inputs_str(file_list)
+    if hw_accel:
+        # Decode each input on the GPU; concat filter runs on CPU frames
+        files_str = " ".join(f'-hwaccel cuda -i "{f}"' for f in file_list)
+        out_codec = opt.HW_ACCEL_CODECS.get(first.video_codec or "", "hevc_nvenc")
+        log.logger.info("Using GPU acceleration: decode=cuda, encode=%s", out_codec)
+    else:
+        files_str = filters.inputs_str(file_list)
+        out_codec = "libx265"
+
     cmd = f'{files_str} -filter_complex "{cmplx}" {mapping} -s "{str(first.resolution)}"'
-    cmd += f' -vcodec "libx265" -b:v "{str(first.video_bitrate)}" "{target_file}"'
+    cmd += f' -vcodec "{out_codec}" -b:v "{str(first.video_bitrate)}" "{target_file}"'
     util.run_ffmpeg(cmd.strip(), total_duration)
     return target_file
 


### PR DESCRIPTION
## Summary

- Add `--hw_accel` flag (`auto`/`on`/`off`) to `video-concat`, consistent with `video-encode`
- When GPU is available, each input is decoded with `-hwaccel cuda` (faster decode); the `concat` filter runs on CPU frames (ffmpeg's concat filter does not support CUDA frames directly); output is encoded with the nvenc equivalent of the source codec (`h264` → `h264_nvenc`, `hevc` → `hevc_nvenc`)
- GPU availability is auto-detected at startup by default (same probe used by `video-encode`)
- Make `-o`/`--outputfile` required (was already enforced in practice by the concat logic)

## Test plan

- [ ] `video-concat -i a.mp4 b.mp4 -o out.mp4` works as before (auto-detects GPU)
- [ ] `video-concat -i a.mp4 b.mp4 -o out.mp4 --hw_accel on` uses `h264_nvenc` / `hevc_nvenc` in the ffmpeg command
- [ ] `video-concat -i a.mp4 b.mp4 -o out.mp4 --hw_accel off` uses `libx265` (CPU path unchanged)
- [ ] Output contains all audio tracks from source files
- [ ] ETA is displayed during concatenation

🤖 Generated with [Claude Code](https://claude.com/claude-code)