### PR TITLE
encodeauto: fix crash on directory input and paths with spaces

### DIFF
--- a/mediatools/encodeauto.py
+++ b/mediatools/encodeauto.py
@@ -19,8 +19,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-# This script applies the ffmpeg deshake filter on a video file
-# to improve image stabilization
+# This script applies a configurable before/after ffmpeg command to one or more video files.
+# Accepts a single file or a directory (all video files in the directory are processed).
 
 import os
 import argparse
@@ -30,41 +30,30 @@ import mediatools.videofile as video
 import utilities.file as fileutil
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Simple encoder")
-    parser.add_argument("-i", "--inputfiles", type=str, required=True)
-    parser.add_argument("-g", "--debug", required=False)
-    parser.add_argument("--nooverwrite", required=False, default=False, action="store_true")
-    parser.add_argument("--keepName", required=False, default=False, action="store_true")
-    parser.add_argument("--before", nargs="*", required=True)
-    parser.add_argument("--after", nargs="*", required=True)
-    # parser.add_argument('args', nargs=argparse.REMAINDER)
-    kwargs = vars(parser.parse_args())
-    util.set_debug_level(kwargs.get("debug", 3))
-    inputfile = kwargs.pop("inputfiles")
-    filesplit = inputfile.split(".")
-    before = " ".join(kwargs.pop("before"))
-    after = " ".join(kwargs.pop("after"))
-    force = not kwargs.pop("nooverwrite")
+def encode_file(inputfile: str, before: str, after: str, force: bool) -> None:
+    """Encode a single video file with the given before/after ffmpeg options."""
+    base, ext = os.path.splitext(inputfile)
+    ext = ext.lstrip(".").lower()
 
-    is_original = len(filesplit) >= 3 and filesplit[-2] == "original"
+    is_original = base.endswith(".original")
     if is_original:
-        del filesplit[-2]
-    base = fileutil.basename(inputfile, strip_dir=False)
-    ext = fileutil.extension(inputfile).lower()
+        base = base[: -len(".original")]
+
+    file_after = after
     new_ext = ext
     if ext in ("mts", "avi", "mkv"):
-        after = f"-vf yadif_cuda=deint=all {after}"
+        file_after = f"-vf yadif_cuda=deint=all {after}"
         new_ext = "mp4"
-    logger.info("Input = %s, Base = %s ext = %s", inputfile, base, new_ext)
+
+    logger.info("Encoding %s (ext=%s)", inputfile, ext)
     seq = 0
     if not force:
         while os.path.isfile(f"{base}.encode.{seq:02}.{new_ext}"):
             seq += 1
     outputfile = f"{base}.encode.{seq:02}.{new_ext}"
 
-    cmd = f'{before} -i "{inputfile}" {after} "{outputfile}"'
-    logger.info("COMMAND = %s %s", "ffmpeg", cmd)
+    cmd = f'{before} -i "{inputfile}" {file_after} "{outputfile}"'
+    logger.info("COMMAND = ffmpeg %s", cmd)
     util.run_ffmpeg(params=cmd, duration=video.get_duration(inputfile))
 
     video.set_creation_date(outputfile, video.get_creation_date(inputfile))
@@ -74,9 +63,34 @@ def main():
             fileutil.rename(inputfile, renamed, force)
             fileutil.rename(outputfile, inputfile, force)
         else:
-            os.rename(outputfile, ".".join(filesplit))
+            os.rename(outputfile, f"{base}.{ext}")
     else:
         fileutil.rename(outputfile, f"{base}.{new_ext}", force)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple encoder — accepts a file or directory")
+    parser.add_argument("-i", "--inputfiles", type=str, required=True)
+    parser.add_argument("-g", "--debug", required=False)
+    parser.add_argument("--nooverwrite", required=False, default=False, action="store_true")
+    parser.add_argument("--keepName", required=False, default=False, action="store_true")
+    parser.add_argument("--before", nargs="*", required=True)
+    parser.add_argument("--after", nargs="*", required=True)
+    kwargs = vars(parser.parse_args())
+    util.set_debug_level(kwargs.get("debug", 3))
+
+    inputpath = kwargs["inputfiles"]
+    before = " ".join(kwargs["before"])
+    after = " ".join(kwargs["after"])
+    force = not kwargs["nooverwrite"]
+
+    files = fileutil.file_list(inputpath, file_type=fileutil.FileType.VIDEO_FILE)
+    if not files:
+        logger.error("No video files found in %s", inputpath)
+        return
+
+    for f in files:
+        encode_file(f, before, after, force)
 
 
 if __name__ == "__main__":

--- a/mediatools/encodeauto.py
+++ b/mediatools/encodeauto.py
@@ -23,7 +23,6 @@
 # Accepts a single file or a directory (all video files in the directory are processed).
 
 import os
-import time
 import argparse
 from mediatools.log import logger
 import mediatools.utilities as util
@@ -98,15 +97,10 @@ def main():
     logger.info("%d file(s) to encode, total duration: %s", n, util.to_hms_str(total_dur))
 
     processed_dur = 0.0
-    wall_start = time.monotonic()
 
     for i, (f, dur) in enumerate(zip(files, durations)):
         encode_file(f, before, after, force, duration=dur)
         processed_dur += dur
-        wall_elapsed = time.monotonic() - wall_start
-        remaining_dur = total_dur - processed_dur
-        speed = processed_dur / wall_elapsed if wall_elapsed > 0 else 0.0
-        eta = util.to_hms_str(remaining_dur / speed) if speed > 0 else "unknown"
         pct = 100.0 * processed_dur / total_dur if total_dur > 0 else 100.0
         logger.info("Processed %d/%d - %.0f%%", i + 1, n, pct)
 

--- a/mediatools/encodeauto.py
+++ b/mediatools/encodeauto.py
@@ -107,15 +107,8 @@ def main():
         remaining_dur = total_dur - processed_dur
         speed = processed_dur / wall_elapsed if wall_elapsed > 0 else 0.0
         eta = util.to_hms_str(remaining_dur / speed) if speed > 0 else "unknown"
-        logger.info(
-            "Progress: %d/%d files | %s / %s encoded (%.0f%%) | Speed: %.2fx | ETA: %s",
-            i + 1, n,
-            util.to_hms_str(processed_dur),
-            util.to_hms_str(total_dur),
-            100.0 * processed_dur / total_dur if total_dur > 0 else 100.0,
-            speed,
-            eta,
-        )
+        pct = 100.0 * processed_dur / total_dur if total_dur > 0 else 100.0
+        logger.info("Processed %d/%d - %.0f%%", i + 1, n, pct)
 
 
 if __name__ == "__main__":

--- a/mediatools/encodeauto.py
+++ b/mediatools/encodeauto.py
@@ -23,6 +23,7 @@
 # Accepts a single file or a directory (all video files in the directory are processed).
 
 import os
+import time
 import argparse
 from mediatools.log import logger
 import mediatools.utilities as util
@@ -30,7 +31,7 @@ import mediatools.videofile as video
 import utilities.file as fileutil
 
 
-def encode_file(inputfile: str, before: str, after: str, force: bool) -> None:
+def encode_file(inputfile: str, before: str, after: str, force: bool, duration: float | None = None) -> None:
     """Encode a single video file with the given before/after ffmpeg options."""
     base, ext = os.path.splitext(inputfile)
     ext = ext.lstrip(".").lower()
@@ -54,7 +55,9 @@ def encode_file(inputfile: str, before: str, after: str, force: bool) -> None:
 
     cmd = f'{before} -i "{inputfile}" {file_after} "{outputfile}"'
     logger.info("COMMAND = ffmpeg %s", cmd)
-    util.run_ffmpeg(params=cmd, duration=video.get_duration(inputfile))
+    if duration is None:
+        duration = video.get_duration(inputfile)
+    util.run_ffmpeg(params=cmd, duration=duration)
 
     video.set_creation_date(outputfile, video.get_creation_date(inputfile))
     if ext == new_ext:
@@ -89,8 +92,30 @@ def main():
         logger.error("No video files found in %s", inputpath)
         return
 
-    for f in files:
-        encode_file(f, before, after, force)
+    n = len(files)
+    durations = [video.get_duration(f) or 0.0 for f in files]
+    total_dur = sum(durations)
+    logger.info("%d file(s) to encode, total duration: %s", n, util.to_hms_str(total_dur))
+
+    processed_dur = 0.0
+    wall_start = time.monotonic()
+
+    for i, (f, dur) in enumerate(zip(files, durations)):
+        encode_file(f, before, after, force, duration=dur)
+        processed_dur += dur
+        wall_elapsed = time.monotonic() - wall_start
+        remaining_dur = total_dur - processed_dur
+        speed = processed_dur / wall_elapsed if wall_elapsed > 0 else 0.0
+        eta = util.to_hms_str(remaining_dur / speed) if speed > 0 else "unknown"
+        logger.info(
+            "Progress: %d/%d files | %s / %s encoded (%.0f%%) | Speed: %.2fx | ETA: %s",
+            i + 1, n,
+            util.to_hms_str(processed_dur),
+            util.to_hms_str(total_dur),
+            100.0 * processed_dur / total_dur if total_dur > 0 else 100.0,
+            speed,
+            eta,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Directory input**: `file_list(inputpath, file_type=VIDEO_FILE)` expands a directory to all video files inside it; a single file path still works as before
- **Spaces and dots in paths**: replaced `inputfile.split(".")` with `os.path.splitext()` which correctly handles filenames and directories containing spaces or dots (e.g. `C:\My.Folder\video name.mp4`)
- **`.original` detection**: uses `base.endswith(".original")` instead of the fragile dot-split index check
- **Refactor**: extracted `encode_file()` so per-file logic is isolated and `main()` is just argument parsing + loop

## Root cause

Passing a directory with no extension (e.g. `C:\Videos\Tignes 2025`) caused:
1. `split(".")` with no dot → `basename()` returned `""` and `extension()` returned the entire path
2. The garbled output path was passed to `get_duration()` → `VideoFile()` → `FileTypeError` crash

## Test plan

- [ ] `encodeauto -i video.mp4 --before "..." --after "..."` encodes a single file as before
- [ ] `encodeauto -i "C:\Videos\My Folder" --before "..." --after "..."` processes all video files in the directory
- [ ] Paths containing spaces encode correctly
- [ ] Paths where a directory component contains a dot (e.g. `C:\My.Folder\video.mp4`) encode correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)