### PR TITLE
Add video-enhance tool with stabilization, color enhancement and batch ETA

### DIFF
--- a/batch-files/enhance.bat
+++ b/batch-files/enhance.bat
@@ -1,0 +1,35 @@
+::
+:: media-tools
+:: Copyright (C) 2019-2021 Olivier Korach
+:: mailto:olivier.korach AT gmail DOT com
+::
+:: This program is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 3 of the License, or (at your option) any later version.
+::
+:: This program is distributed in the hope that it will be useful,
+:: but WITHOUT ANY WARRANTY; without even the implied warranty of
+:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+:: Lesser General Public License for more details.
+::
+:: You should have received a copy of the GNU Lesser General Public License
+:: along with this program; if not, write to the Free Software Foundation,
+:: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+::
+:: Usage: drop one or more video files or folders onto this batch file.
+:: Each file is color-enhanced in place (original renamed to .original.<ext>).
+:: Applies the eq color filter (saturation/contrast/brightness/gamma) with CPU encoding by default.
+:: Pass --gpu_filters to use GPU hw acceleration instead (eq filter is then skipped).
+::
+
+@echo off
+
+:loop
+if "%~1"=="" goto end
+video-enhance -i "%~1"
+shift
+goto loop
+
+:end
+pause

--- a/mediatools/encodeauto.py
+++ b/mediatools/encodeauto.py
@@ -23,6 +23,7 @@
 # Accepts a single file or a directory (all video files in the directory are processed).
 
 import os
+import time
 import argparse
 from mediatools.log import logger
 import mediatools.utilities as util
@@ -97,12 +98,16 @@ def main():
     logger.info("%d file(s) to encode, total duration: %s", n, util.to_hms_str(total_dur))
 
     processed_dur = 0.0
+    wall_start = time.time()
 
     for i, (f, dur) in enumerate(zip(files, durations)):
-        encode_file(f, before, after, force, duration=dur)
+        encode_file(f, before, after, force, duration=total_dur - processed_dur)
         processed_dur += dur
         pct = 100.0 * processed_dur / total_dur if total_dur > 0 else 100.0
-        logger.info("Processed %d/%d - %.0f%%", i + 1, n, pct)
+        elapsed = time.time() - wall_start
+        speed = processed_dur / elapsed if elapsed > 0 else 0
+        eta = (total_dur - processed_dur) / speed if speed > 0 else 0
+        logger.info("Processed %d/%d - %.0f%% - ETA %s", i + 1, n, pct, util.to_hms_str(eta))
 
 
 if __name__ == "__main__":

--- a/mediatools/stabilize.py
+++ b/mediatools/stabilize.py
@@ -37,7 +37,7 @@ import utilities.file as fil
 from mediatools import log
 
 
-def _has_vidstab() -> bool:
+def has_vidstab() -> bool:
     """Return True if FFmpeg was compiled with libvidstab support."""
     try:
         quot = '"' if platform.system() == "Windows" else ""
@@ -51,6 +51,16 @@ def _has_vidstab() -> bool:
         return False
 
 
+def run_vidstabdetect(filename: str, shakiness: int = 8) -> str:
+    """Run pass 1 of vidstab: analyse motion and return path of the transforms file."""
+    null_out = "NUL" if platform.system() == "Windows" else "/dev/null"
+    with tempfile.NamedTemporaryFile(suffix=".trf", delete=False) as tf:
+        trf_file = tf.name
+    detect_vf = f"vidstabdetect=shakiness={shakiness}:accuracy=15:result='{trf_file}'"
+    util.run_ffmpeg(f'-i "{filename}" -vf "{detect_vf}" -f null "{null_out}"')
+    return trf_file
+
+
 def stabilize(filename: str, output: str | None = None, shakiness: int = 8, smoothing: int = 30,
               zoom: int = 0, optzoom: int = 1, sharpen: bool = True, **kwargs) -> str:
     """Stabilize a video file using a two-pass libvidstab pipeline.
@@ -60,7 +70,7 @@ def stabilize(filename: str, output: str | None = None, shakiness: int = 8, smoo
     """
     output = util.automatic_output_file_name(infile=filename, outfile=output, postfix="stabilized")
 
-    if not _has_vidstab():
+    if not has_vidstab():
         log.logger.warning("libvidstab not found in FFmpeg — falling back to deshake filter")
         kwargs["deshake"] = "32x32"
         kwargs["hw_accel"] = False  # deshake filter is CPU-only, incompatible with hwaccel

--- a/mediatools/video_enhance.py
+++ b/mediatools/video_enhance.py
@@ -1,0 +1,131 @@
+#!python3
+#
+# media-tools
+# Copyright (C) 2019-2021 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""Enhances video colors to produce more vivid, punchy images using the ffmpeg eq filter."""
+
+import os
+import time
+import mediatools.utilities as util
+import mediatools.videofile as video
+import mediatools.stabilize as stab
+import utilities.file as fileutil
+from mediatools import log
+
+
+def enhance_file(input_file: str, output_file: str | None,
+                 saturation: float, contrast: float, brightness: float, gamma: float,
+                 hw_accel: bool | None = None, stabilize: bool = True,
+                 batch_remaining: float | None = None) -> None:
+    """Color-enhance a single video file, preserve creation date, rename original."""
+    creation_date = video.get_creation_date(input_file)
+    extra = {} if hw_accel is None else {"hw_accel": hw_accel}
+    if batch_remaining is not None:
+        extra["batch_remaining"] = batch_remaining
+
+    trf_file = None
+    if stabilize:
+        if stab.has_vidstab():
+            try:
+                trf_file = stab.run_vidstabdetect(input_file)
+                extra["vidstab_trf"] = trf_file
+            except Exception as e:
+                log.logger.warning("vidstabdetect failed for %s, skipping stabilization: %s", input_file, e)
+        else:
+            log.logger.warning("libvidstab not available — falling back to deshake filter")
+            extra["deshake"] = "32x32"
+
+    try:
+        outfile = video.color_enhance(input_file, output_file, saturation=saturation,
+                                      contrast=contrast, brightness=brightness, gamma=gamma, **extra)
+    except Exception as e:
+        log.logger.error("Failed to enhance %s: %s", input_file, e)
+        return
+    finally:
+        if trf_file and os.path.exists(trf_file):
+            os.unlink(trf_file)
+    video.set_creation_date(outfile, creation_date)
+
+    if output_file is None:
+        base, ext = os.path.splitext(input_file)
+        fileutil.rename(input_file, f"{base}.original{ext}")
+        fileutil.rename(outfile, input_file)
+        util.generated_file(input_file)
+    else:
+        util.generated_file(outfile)
+
+
+def main():
+    parser = util.get_common_args("video-enhance", "Enhance video colors (saturation, contrast, brightness, gamma)")
+    parser.add_argument("--saturation", required=False, type=float, default=1.3,
+                        help="Color saturation multiplier (default 1.3, neutral 1.0, range 0-3)")
+    parser.add_argument("--contrast", required=False, type=float, default=1.1,
+                        help="Contrast multiplier (default 1.1, neutral 1.0, range -2 to 2)")
+    parser.add_argument("--brightness", required=False, type=float, default=0.0,
+                        help="Brightness offset (default 0.0, range -1 to 1)")
+    parser.add_argument("--gamma", required=False, type=float, default=1.0,
+                        help="Gamma correction (default 1.0, range 0.1 to 10)")
+    parser.add_argument("--gpu_filters", required=False, default=False, action="store_true",
+                        help="Use GPU hw acceleration with GPU-compatible filters only (disables eq color filter)")
+    parser.add_argument("--no_stabilize", required=False, default=False, action="store_true",
+                        help="Skip video stabilization (stabilization is applied by default)")
+    kwargs = util.parse_media_args(parser)
+
+    output_file = kwargs.get("outputfile", None)
+    saturation = kwargs["saturation"]
+    contrast = kwargs["contrast"]
+    brightness = kwargs["brightness"]
+    gamma = kwargs["gamma"]
+    hw_accel = None if kwargs.get("gpu_filters", False) else False
+    do_stabilize = not kwargs.get("no_stabilize", False)
+
+    all_files = fileutil.file_list(*kwargs["inputfiles"], file_type=fileutil.FileType.VIDEO_FILE, recurse=True)
+    files = [f for f in all_files if ".color." not in os.path.basename(f) and ".original." not in os.path.basename(f)]
+    if len(files) < len(all_files):
+        log.logger.info("Skipped %d already-generated file(s) (.color./.original.)", len(all_files) - len(files))
+    if not files:
+        log.logger.error("No video files found in %s", kwargs["inputfiles"])
+        return
+
+    if output_file is not None and len(files) > 1:
+        log.logger.error("-o/--outputfile cannot be used with multiple input files; omit it to rename in place")
+        return
+
+    n = len(files)
+    durations = [video.get_duration(f) or 0.0 for f in files]
+    total_dur = sum(durations)
+    log.logger.info("%d file(s) to enhance, total duration: %s", n, util.to_hms_str(total_dur))
+
+    processed_dur = 0.0
+    wall_start = time.time()
+
+    for i, (f, dur) in enumerate(zip(files, durations)):
+        enhance_file(f, output_file, saturation, contrast, brightness, gamma,
+                     hw_accel=hw_accel, stabilize=do_stabilize, batch_remaining=total_dur - processed_dur)
+        processed_dur += dur
+        pct = 100.0 * processed_dur / total_dur if total_dur > 0 else 100.0
+        elapsed = time.time() - wall_start
+        speed = processed_dur / elapsed if elapsed > 0 else 0
+        eta = (total_dur - processed_dur) / speed if speed > 0 else 0
+        log.logger.info("Processed %d/%d - %.0f%% - ETA %s", i + 1, n, pct, util.to_hms_str(eta))
+
+
+if __name__ == "__main__":
+    main()

--- a/mediatools/videofile.py
+++ b/mediatools/videofile.py
@@ -384,7 +384,7 @@ class VideoFile(media.MediaFile):
 
         cmd = f'{" ".join(input_settings)} -i "{self.filename}" {" ".join(prefilter_settings)}'
         cmd += f'{str(video_filters)} {str(audio_filters)} {output_str} {mapping} "{target_file}"'
-        util.run_ffmpeg(cmd, self.duration)
+        util.run_ffmpeg(cmd, kwargs.get("batch_remaining", self.duration))
         log.logger.info("File %s encoded", target_file)
         return target_file
 
@@ -464,11 +464,19 @@ class VideoFile(media.MediaFile):
             if not kwargs.get("no_crop", False):
                 w, h = self.dimensions()
                 vfilters.append(filter.crop(w - rx, h - ry, rx // 2, ry // 2))
+        if kwargs.get("vidstab_trf", None) is not None:
+            trf = kwargs["vidstab_trf"]
+            vfilters.append(f"vidstabtransform=input='{trf}',unsharp=5:5:0.8:3:3:0.4")
         if kwargs.get("fade", False):
             vfilters.append(filter.FadeIn(duration=0.5))
             vfilters.append(filter.FadeOut(duration=0.5))
         if util.use_hardware_accel(**kwargs) and kwargs.get(opt.Option.RESOLUTION, None) is not None:
             vfilters.append(f"scale_cuda={kwargs[opt.Option.WIDTH]}:{kwargs[opt.Option.HEIGHT]}")
+        if kwargs.get("color_eq", None) is not None:
+            if util.use_hardware_accel(**kwargs):
+                log.logger.warning("Skipping eq color filter: not compatible with GPU hw acceleration (use --software_filters to enable)")
+            else:
+                vfilters.append(kwargs["color_eq"])
         log.logger.debug("vfilters = %s", str(vfilters))
         return vfilters
 
@@ -718,6 +726,18 @@ def reverse(filename: str, output: str | None = None, mute: bool = True, **kwarg
     return VideoFile(filename).encode(reverse=True, target_file=output, mute=mute, **kwargs)
 
 
+def color_enhance(filename: str, output: str | None = None, saturation: float = 1.3, contrast: float = 1.1,
+                  brightness: float = 0.0, gamma: float = 1.0, **kwargs) -> str:
+    """Enhances video colors using the ffmpeg eq filter (saturation, contrast, brightness, gamma)."""
+    eq = f"eq=saturation={saturation}:contrast={contrast}:brightness={brightness}:gamma={gamma}"
+    log.logger.info("Color enhancing %s: %s", filename, eq)
+    output = util.automatic_output_file_name(outfile=output, infile=filename, postfix="color")
+    vf = VideoFile(filename)
+    if vf.video_bitrate and "vbitrate" not in kwargs:
+        kwargs["vbitrate"] = vf.video_bitrate
+    return vf.encode(target_file=output, color_eq=eq, **kwargs)
+
+
 def deshake(filename: str, output: str | None = None, **kwargs) -> str:
     output = util.automatic_output_file_name(infile=filename, outfile=output, postfix="deshake")
     return VideoFile(filename).encode(target_file=output, **kwargs)
@@ -729,42 +749,43 @@ def set_creation_date(filename: str, new_date: datetime.datetime | None) -> bool
     exif_date = datetime.datetime.strftime(new_date, util.EXIF_DATE_FMT)
     log.logger.info("Setting creation date of %s to %s", filename, exif_date)
     p = ["-P", "-overwrite_original"]
-    with ExifToolHelper(executable=util.get_exiftool()) as et:
-        et.set_tags([filename], tags={"File:FileCreateDate": exif_date, "File:FileModifyDate": exif_date}, params=p)
-        if fil.is_image_file(filename):
-            et.set_tags([filename], tags={"DateTimeOriginal": exif_date}, params=p)
-        elif fil.is_video_file(filename):
-            log.logger.info("Tagging video file")
-            et.set_tags([filename], tags={"CreateDate": exif_date, "ModifyDate": exif_date, "DateTimeOriginal": exif_date}, params=p)
-            et.set_tags(
-                [filename],
-                tags={
-                    # "CreateDate": new_date,
-                    # "ModifyDate": new_date,
-                    # "DateTimeOriginal": new_date,
-                    "EXIF:CreateDate": exif_date,
-                    "EXIF:ModifyDate": exif_date,
-                    "EXIF:DateTimeOriginal": exif_date,
-                },
-                params=p,
-            )
-            et.set_tags(
-                [filename],
-                tags={
-                    "Composite:SubSecCreateDate": exif_date,
-                    "Composite:SubSecDateTimeOriginal": exif_date,
-                    "Composite:SubSecModifyDate": exif_date,
-                    "Quicktime:CreateDate": exif_date,
-                    "Quicktime:DateTimeOriginal": exif_date,
-                    "QuickTime:MediaCreateDate": exif_date,
-                    "QuickTime:MediaModifyDate": exif_date,
-                    "QuickTime:TrackCreateDate": exif_date,
-                    "QuickTime:TrackModifyDate": exif_date,
-                    "QuickTime:CreateDate": exif_date,
-                    "QuickTime:ModifyDate": exif_date,
-                },
-                params=p,
-            )
+    try:
+        with ExifToolHelper(executable=util.get_exiftool()) as et:
+            et.set_tags([filename], tags={"File:FileCreateDate": exif_date, "File:FileModifyDate": exif_date}, params=p)
+            if fil.is_image_file(filename):
+                et.set_tags([filename], tags={"DateTimeOriginal": exif_date}, params=p)
+            elif fil.is_video_file(filename):
+                log.logger.info("Tagging video file")
+                et.set_tags([filename], tags={"CreateDate": exif_date, "ModifyDate": exif_date, "DateTimeOriginal": exif_date}, params=p)
+                et.set_tags(
+                    [filename],
+                    tags={
+                        "EXIF:CreateDate": exif_date,
+                        "EXIF:ModifyDate": exif_date,
+                        "EXIF:DateTimeOriginal": exif_date,
+                    },
+                    params=p,
+                )
+                et.set_tags(
+                    [filename],
+                    tags={
+                        "Composite:SubSecCreateDate": exif_date,
+                        "Composite:SubSecDateTimeOriginal": exif_date,
+                        "Composite:SubSecModifyDate": exif_date,
+                        "Quicktime:CreateDate": exif_date,
+                        "Quicktime:DateTimeOriginal": exif_date,
+                        "QuickTime:MediaCreateDate": exif_date,
+                        "QuickTime:MediaModifyDate": exif_date,
+                        "QuickTime:TrackCreateDate": exif_date,
+                        "QuickTime:TrackModifyDate": exif_date,
+                        "QuickTime:CreateDate": exif_date,
+                        "QuickTime:ModifyDate": exif_date,
+                    },
+                    params=p,
+                )
+    except Exception as e:
+        log.logger.warning("Could not set creation date of %s: %s", filename, e)
+        return False
     log.logger.info("File %s creation date updated", filename)
     return True
 
@@ -777,6 +798,9 @@ def get_creation_date(filename: str) -> datetime.datetime | None:
         return creation_date
     except FileNotFoundError:
         log.logger.warning("exiftool not found, cannot read creation date of %s", filename)
+        return None
+    except Exception as e:
+        log.logger.warning("Could not read creation date of %s: %s", filename, e)
         return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ encode           = "cli.encode:main"
 audio-split      = "mediatools.audiosplit:main"
 audio-concat     = "mediatools.audioconcat:main"
 audio-speed      = "mediatools.audiospeed:main"
+video-enhance    = "mediatools.video_enhance:main"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0", "wheel", "twine"]

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setuptools.setup(
             "audio-split = mediatools.audiosplit:main",
             "audio-concat = mediatools.audioconcat:main",
             "audio-speed = mediatools.audiospeed:main",
+            "video-enhance = mediatools.video_enhance:main",
         ]
     },
     python_requires=">=3.10",


### PR DESCRIPTION
## Summary

- **New `video-enhance` CLI** (`mediatools/video_enhance.py`): single command that applies two-pass vidstab stabilization + `eq` color filter (saturation, contrast, brightness, gamma) in one encode pass using CPU by default
  - `--no_stabilize`: skip stabilization (e.g. for already-steady footage)
  - `--gpu_filters`: switch to GPU/nvenc pipeline (skips CPU-only filters)
  - Skips `.color.`/`.original.` files to avoid reprocessing previous outputs
  - Per-file exceptions caught and logged; batch continues on error
- **New `batch-files/enhance.bat`**: drag-and-drop wrapper for `video-enhance`
- **`stabilize.py`**: `_has_vidstab()` → `has_vidstab()` (public); new `run_vidstabdetect()` helper for use by other tools
- **`videofile.py`**: `vidstab_trf` kwarg in `__get_video_filters()` to chain `vidstabtransform+unsharp` into a single encode pass; `batch_remaining` kwarg in `encode()` so the live ffmpeg ETA reflects total remaining batch duration, not just the current file
- **`encodeauto.py`**: ETA added to post-file progress log; same `batch_remaining` approach for accurate cross-file ETA

## Test plan

- [ ] `video-enhance -i <dir>` processes all video files, skips `.color.`/`.original.` leftovers, logs `Processed N/T - X% - ETA HH:MM:SS` after each file
- [ ] ETA during encoding counts down across the whole batch (not per-file)
- [ ] `--no_stabilize` skips vidstabdetect pass
- [ ] `--gpu_filters` uses nvenc without eq/vidstab filters
- [ ] `enhance.bat` drag-and-drop works with paths containing spaces
- [ ] `encodeauto` ETA spans all files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)