### PR TITLE
Fix video-speed crash: -an and -map 0:a are mutually exclusive

### DIFF
--- a/mediatools/videofile.py
+++ b/mediatools/videofile.py
@@ -379,8 +379,11 @@ class VideoFile(media.MediaFile):
 
         output_str = media.build_ffmpeg_options({**raw_settings, **output_settings})
 
-        # Preserve all audio streams and subtitle/text streams from the source
-        mapping = "-map 0:v:0 -map 0:a -map 0:s? -c:s copy"
+        # Preserve all audio and subtitle streams unless audio is explicitly muted (-an)
+        if kwargs.get(opt.Option.MUTE, False):
+            mapping = "-map 0:v:0"
+        else:
+            mapping = "-map 0:v:0 -map 0:a -map 0:s? -c:s copy"
 
         cmd = f'{" ".join(input_settings)} -i "{self.filename}" {" ".join(prefilter_settings)}'
         cmd += f'{str(video_filters)} {str(audio_filters)} {output_str} {mapping} "{target_file}"'


### PR DESCRIPTION
## Summary

- When `mute=True` (e.g. `video-speed` with `-an`), `encode()` was emitting both `-an` and `-map 0:a`, which ffmpeg rejects as invalid
- Skip `-map 0:a` and `-map 0:s?` when audio is muted; keep `-map 0:v:0` only

## Test plan
- [ ] `video-speed -i file.mp4 --mute` completes without error
- [ ] `video-speed -i file.mp4` (no mute) still preserves all audio streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)