### PR TITLE
Fix ETA for video-speed: base on output duration not input duration

### DIFF
--- a/mediatools/version.py
+++ b/mediatools/version.py
@@ -19,4 +19,4 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-MEDIA_TOOLS_VERSION: str = "0.6"
+MEDIA_TOOLS_VERSION: str = "0.7"

--- a/mediatools/videofile.py
+++ b/mediatools/videofile.py
@@ -387,7 +387,16 @@ class VideoFile(media.MediaFile):
 
         cmd = f'{" ".join(input_settings)} -i "{self.filename}" {" ".join(prefilter_settings)}'
         cmd += f'{str(video_filters)} {str(audio_filters)} {output_str} {mapping} "{target_file}"'
-        util.run_ffmpeg(cmd, kwargs.get("batch_remaining", self.duration))
+        eta_duration = kwargs.get("batch_remaining", self.duration)
+        speed_val = kwargs.get("speed", None)
+        if speed_val is not None:
+            try:
+                speed_factor = float(util.percent_or_absolute(str(speed_val)))
+                if speed_factor > 0:
+                    eta_duration = eta_duration / speed_factor
+            except ValueError:
+                pass
+        util.run_ffmpeg(cmd, eta_duration)
         log.logger.info("File %s encoded", target_file)
         return target_file
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "audio-video-tools"
-version = "0.6"
+version = "0.7"
 description = "A collection of utility scripts to manipulate media files (audio, video, image)"
 authors = [
     {name = "Olivier Korach", email = "olivier.korach@gmail.com"},


### PR DESCRIPTION
## Summary

When encoding a speed-changed video, ffmpeg's `time=` progress counter reflects the **output** file position. For a 4x speed-up the output is 4× shorter than the input, so the ETA was counting down 4× too slowly.

Fix: divide `eta_duration` by the speed factor before passing it to `run_ffmpeg()`. Handles numeric strings (`"4"`, `"0.5"`) and percentage strings (`"400%"`) via `util.percent_or_absolute`. ValueError is caught so any unexpected format falls back to the original duration silently.

## Test plan
- [ ] `video-speed -i file.mp4 --speed 4` shows ETA based on output duration (≈ input/4)
- [ ] `video-speed -i file.mp4 --speed 0.5` shows ETA based on output duration (≈ input×2)
- [ ] Normal encodes without `--speed` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)