### PR TITLE
Add OGG audio file support and fix batch file delayed expansion

### DIFF
--- a/batch-files-audio/mp3 192.bat
+++ b/batch-files-audio/mp3 192.bat
@@ -17,6 +17,6 @@
 :: along with this program; if not, write to the Free Software Foundation,
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 video-encode -i %* -p mp3_192k --abitrate 192k
 pause

--- a/batch-files/1080p vertical.bat
+++ b/batch-files/1080p vertical.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --vbitrate 6000k --acodec aac --abitrate 128k --fps 50
 

--- a/batch-files/1080p x264 50fps.bat
+++ b/batch-files/1080p x264 50fps.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x264 --width 1920 --vbitrate 6000k --acodec aac --abitrate 128k --fps 50
 

--- a/batch-files/1080p x265 25fps.bat
+++ b/batch-files/1080p x265 25fps.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 1920 --vbitrate 6000k --acodec aac --abitrate 128k --fps 25
 

--- a/batch-files/1080p x265 30fps.bat
+++ b/batch-files/1080p x265 30fps.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 1920 --vbitrate 6000k --acodec aac --abitrate 128k --fps 30
 

--- a/batch-files/1080p x265 50fps.bat
+++ b/batch-files/1080p x265 50fps.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 1920 --vbitrate 6000k --acodec aac --abitrate 128k --fps 50
 

--- a/batch-files/1080p x265 60fps.bat
+++ b/batch-files/1080p x265 60fps.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 1920 --vbitrate 6000k --acodec aac --abitrate 128k --fps 60
 

--- a/batch-files/2.5K GOPRO.bat
+++ b/batch-files/2.5K GOPRO.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 2560 --height 1440 --vbitrate 12000k --acodec aac --abitrate 128k
 

--- a/batch-files/4K DJI.bat
+++ b/batch-files/4K DJI.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 3840 --vbitrate 20000k --acodec aac --abitrate 128k
 

--- a/batch-files/720p x265 25fps.bat
+++ b/batch-files/720p x265 25fps.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x265 --width 1280 --vbitrate 2500k --acodec aac --abitrate 128k --fps 25
 

--- a/batch-files/_Custom Encode.bat
+++ b/batch-files/_Custom Encode.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 set vcodec=h265
 set vbitrate=12000k

--- a/batch-files/_Pinnacle 1080p CPU.bat
+++ b/batch-files/_Pinnacle 1080p CPU.bat
@@ -18,6 +18,6 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel off --vcodec x264 --width 1920 --vbitrate 20000k --acodec aac --abitrate 128k

--- a/batch-files/_Pinnacle 1080p GPU.bat
+++ b/batch-files/_Pinnacle 1080p GPU.bat
@@ -18,6 +18,6 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x264 --width 1920 --vbitrate 20000k --acodec aac --abitrate 128k

--- a/batch-files/_Pinnacle GPU 2.5K.bat
+++ b/batch-files/_Pinnacle GPU 2.5K.bat
@@ -18,7 +18,7 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-setlocal enabledelayedexpansion
+:: setlocal enabledelayedexpansion
 
 encode -i %* --hw_accel on --vcodec x264 --width 2560 --vbitrate 30000k --acodec aac --abitrate 128k
 

--- a/mediatools/audiofile.py
+++ b/mediatools/audiofile.py
@@ -198,6 +198,7 @@ class AudioFile(media.MediaFile):
         - Profile is the encoding profile as per the VideoTools.properties config file
         - **kwargs accepts at large panel of other ptional options"""
         kwargs = util.get_all_options(fil.FileType.AUDIO_FILE, **kwargs)
+        kwargs["hw_accel"] = False
         log.logger.debug("Audio encoding %s with profile %s and args %s", self.filename, profile, str(kwargs))
         if target_file is None:
             target_file = media.build_target_file(self.filename, profile)
@@ -215,9 +216,12 @@ class AudioFile(media.MediaFile):
         elif ext in ("m3a", "aac") and output_settings[opt.OptionFfmpeg.ACODEC] != "copy":
             output_settings[opt.OptionFfmpeg.ACODEC] = "aac"
             log.logger.info("Patching codec for AAC audio output")
+        elif ext == "ogg" and output_settings[opt.OptionFfmpeg.ACODEC] != "copy":
+            output_settings[opt.OptionFfmpeg.ACODEC] = "libvorbis"
+            log.logger.info("Patching codec for OGG audio output")
         output_str = media.build_ffmpeg_options({**raw_settings, **output_settings})
 
-        log.logger.info("Encoding mp3 %s", target_file)
+        log.logger.info("Encoding audio %s", target_file)
         cmd = f'{" ".join(input_settings)} -i "{self.filename}" {" ".join(prefilter_settings)}'
         cmd += f' {str(audio_filters)} {output_str} "{target_file}"'
         util.run_ffmpeg(cmd, self.duration)

--- a/mediatools/encode.py
+++ b/mediatools/encode.py
@@ -40,8 +40,10 @@ def encode_file(file: str, file_type: str, **kwargs) -> str:
     """Encodes a single file"""
     if file_type == fil.FileType.AUDIO_FILE:
         file_object = audio.AudioFile(file)
-    else:
+    elif file_type == fil.FileType.VIDEO_FILE:
         file_object = video.VideoFile(file)
+    else:
+        raise ValueError(f"File {file} is not an audio or video file")
 
     if kwargs.get("timeranges", None) is None:
         outfile = file_object.encode(kwargs.get("outputfile", None), **kwargs)

--- a/utilities/file.py
+++ b/utilities/file.py
@@ -286,29 +286,27 @@ def __is_type_file(file: str, type_of_media: str | None) -> bool:
 
 
 def is_audio_file(file: str) -> bool:
-    return __is_type_file(file, FileType.AUDIO_FILE)
+    return __match_extension(file, FileType.FILE_EXTENSIONS[FileType.AUDIO_FILE])
 
 
 def is_video_file(file: str) -> bool:
-    return __is_type_file(file, FileType.VIDEO_FILE)
+    return __match_extension(file, FileType.FILE_EXTENSIONS[FileType.VIDEO_FILE])
 
 
 def is_image_file(file: str) -> bool:
-    return __is_type_file(file, FileType.IMAGE_FILE)
+    return __match_extension(file, FileType.FILE_EXTENSIONS[FileType.IMAGE_FILE])
 
 
 def is_media_file(file: str) -> bool:
     """Returns whether the file has an extension corresponding to media (audio/video/image) files"""
-    return is_audio_file(file) or is_image_file(file) or is_video_file(file)
+    return __match_extension(file, MEDIA_FILE_EXTENSIONS)
 
 
 def get_type(file: str) -> str:
-    if is_audio_file(file):
-        t = FileType.AUDIO_FILE
-    elif is_video_file(file):
-        t = FileType.VIDEO_FILE
-    elif is_image_file(file):
-        t = FileType.IMAGE_FILE
+    for file_type, extensions in FileType.FILE_EXTENSIONS.items():
+        if __match_extension(file, extensions):
+            t = file_type
+            break
     else:
         t = FileType.UNKNOWN_FILE
     log.logger.debug("Filetype of %s is %s", file, t)


### PR DESCRIPTION
## Summary
- **OGG support**: `is_audio/video/image_file()` and `get_type()` in `utilities/file.py` now classify files by extension only — removing the `os.path.isfile()` dependency that caused files on certain drives/paths (where Python returned `False`) to be mistyped as `UNKNOWN_FILE`
- **`encode.py`**: unknown file type now raises `ValueError` instead of silently falling through to `VideoFile`
- **`audiofile.py`**: disables hardware acceleration for audio encoding (CUDA flags broke ffmpeg on audio-only input); adds OGG→`libvorbis` codec patching alongside MP3/AAC; fixes misleading `"Encoding mp3"` log message
- **Batch files**: commented out `setlocal enabledelayedexpansion` in 14 batch files with no loops — cmd.exe delayed expansion strips `!` from filenames, causing ffmpeg "file not found" errors on files like `Look Up! (Audio).ogg`

## Test plan
- [ ] Run `video-encode` on an `.ogg` file — should encode without `FileTypeError` or ffmpeg "no such file" errors
- [ ] Run `video-encode` on a video file with `!` in the filename using an updated batch file — `!` should be preserved
- [ ] Verify batch files with `for` loops still have `setlocal enabledelayedexpansion` active

🤖 Generated with [Claude Code](https://claude.com/claude-code)