### PR TITLE
Add fix-mp3-meta CLI tool for batch MP3 metadata repair

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
     #    python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
           version=$(grep VERSION mediatools/version.py | cut -d "=" -f 2 | sed "s/[\'\" ]//g")
           echo "sonar.projectVersion=$version" >> sonar-project.properties
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/mediatools/fix_mp3_meta.py
+++ b/mediatools/fix_mp3_meta.py
@@ -77,10 +77,10 @@ def _title_case(text: str) -> str:
 
 
 def _sentence_case(text: str) -> str:
-    """Only the very first letter uppercase (track title style)."""
+    """Only the very first letter uppercase, rest lowercase (track title style)."""
     if not text:
         return text
-    return text[0].upper() + text[1:]
+    return text[0].upper() + text[1:].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +118,7 @@ def _parse_file_name(base_name: str) -> tuple[int | None, str | None, str | None
         artist = _title_case(am.group(1).strip())
         title = _sentence_case(am.group(2).strip())
     else:
-        title = _sentence_case(rest)
+        title = _sentence_case(rest) or None
 
     return track, artist, title
 
@@ -264,7 +264,7 @@ def _process_file(filepath: str, dir_artist: str | None, dir_album: str | None, 
     year = existing_year or dir_year
 
     # 4. Try to match title against MusicBrainz track list (if album was looked up)
-    if title is None and track is not None and mb_tracks and (track - 1) < len(mb_tracks):
+    if not title and track is not None and mb_tracks and (track - 1) < len(mb_tracks):
         title = _sentence_case(mb_tracks[track - 1])
 
     # 5. MusicBrainz lookup for year if still missing

--- a/mediatools/fix_mp3_meta.py
+++ b/mediatools/fix_mp3_meta.py
@@ -1,0 +1,369 @@
+#!python3
+#
+# media-tools
+# Copyright (C) 2019-2024 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""
+fix-mp3-meta: Batch fix MP3 metadata for a music library.
+
+For each subdirectory of the root music directory, processes all audio files:
+  - Determines artist and title from tags or filename
+  - Normalises artist (Title Case) and title (Sentence case)
+  - Determines album and track number from directory name or tags
+  - Looks up release year on MusicBrainz when unknown
+  - Writes ID3v1 + ID3v2 tags via mutagen
+  - Sets file creation/modification timestamps to release date (YYYY-01-01 12:00)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import re
+import time
+import argparse
+import datetime
+
+import musicbrainzngs
+import mutagen
+from mutagen.id3 import ID3, TIT2, TPE1, TALB, TRCK, TDRC, ID3NoHeaderError
+from mutagen.mp3 import MP3
+
+from mediatools import log
+import mediatools.utilities as util
+import utilities.file as fil
+
+# ---------------------------------------------------------------------------
+# MusicBrainz setup
+# ---------------------------------------------------------------------------
+musicbrainzngs.set_useragent("audio-video-tools", "0.7", "olivier.korach@gmail.com")
+
+# ---------------------------------------------------------------------------
+# Regex patterns for directory and filename parsing
+# ---------------------------------------------------------------------------
+# Directory: "Artist - Album" or "Artist - Album (Year)" or "Artist"
+_DIR_ARTIST_ALBUM_RE = re.compile(r"^(.+?)\s+-\s+(.+?)(?:\s*[\(\[]\s*(\d{4})\s*[\)\]])?\s*$")
+# Track prefix in filename: "01 ", "01 - ", "01. ", "(01) " etc.
+_TRACK_PREFIX_RE = re.compile(r"^\s*[\(\[]?(\d{1,3})[\)\].]?\s*[-.]?\s*")
+# Artist - Title separator in filename
+_ARTIST_TITLE_RE = re.compile(r"^(.+?)\s+-\s+(.+)$")
+
+
+# ---------------------------------------------------------------------------
+# Capitalisation helpers
+# ---------------------------------------------------------------------------
+
+def _title_case(text: str) -> str:
+    """Every word's first letter uppercase (artist style)."""
+    if not text:
+        return text
+    return " ".join(w.capitalize() for w in text.split())
+
+
+def _sentence_case(text: str) -> str:
+    """Only the very first letter uppercase (track title style)."""
+    if not text:
+        return text
+    return text[0].upper() + text[1:]
+
+
+# ---------------------------------------------------------------------------
+# Filename / directory parsing
+# ---------------------------------------------------------------------------
+
+def _parse_dir_name(dir_name: str) -> tuple[str | None, str | None, int | None]:
+    """Returns (artist, album, year) extracted from a directory base name."""
+    m = _DIR_ARTIST_ALBUM_RE.match(dir_name)
+    if m:
+        artist = _title_case(m.group(1).strip())
+        album = m.group(2).strip()
+        year = int(m.group(3)) if m.group(3) else None
+        return artist, album, year
+    return _title_case(dir_name.strip()), None, None
+
+
+def _parse_file_name(base_name: str) -> tuple[int | None, str | None, str | None]:
+    """Returns (track_number, artist, title) parsed from a file base name (no extension)."""
+    track: int | None = None
+    artist: str | None = None
+    title: str | None = None
+
+    # Strip a leading track number if present
+    tm = _TRACK_PREFIX_RE.match(base_name)
+    if tm:
+        track = int(tm.group(1))
+        rest = base_name[tm.end():].strip()
+    else:
+        rest = base_name.strip()
+
+    # Try "Artist - Title"
+    am = _ARTIST_TITLE_RE.match(rest)
+    if am:
+        artist = _title_case(am.group(1).strip())
+        title = _sentence_case(am.group(2).strip())
+    else:
+        title = _sentence_case(rest)
+
+    return track, artist, title
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz lookup
+# ---------------------------------------------------------------------------
+
+def _mb_lookup_release(artist: str, album: str) -> tuple[int | None, list[str]]:
+    """Returns (year, [track_title, ...]) from MusicBrainz for the best-matching release."""
+    if not artist or not album:
+        return None, []
+    try:
+        result = musicbrainzngs.search_releases(artist=artist, release=album, limit=3)
+        releases = result.get("release-list", [])
+        if not releases:
+            return None, []
+        rel = releases[0]
+        year = None
+        date_str = rel.get("date", "")
+        if date_str:
+            try:
+                year = int(date_str[:4])
+            except ValueError:
+                pass
+        # Fetch full release with tracklist
+        release_id = rel["id"]
+        full = musicbrainzngs.get_release_by_id(release_id, includes=["recordings"])
+        tracks: list[str] = []
+        for medium in full.get("release", {}).get("medium-list", []):
+            for track in medium.get("track-list", []):
+                tracks.append(track.get("recording", {}).get("title", ""))
+        return year, tracks
+    except Exception as e:
+        log.logger.warning("MusicBrainz lookup failed for '%s' / '%s': %s", artist, album, str(e))
+        return None, []
+
+
+def _mb_lookup_track(artist: str, title: str) -> int | None:
+    """Returns the release year for a specific recording from MusicBrainz."""
+    if not artist or not title:
+        return None
+    try:
+        result = musicbrainzngs.search_recordings(artist=artist, recording=title, limit=3)
+        recordings = result.get("recording-list", [])
+        for rec in recordings:
+            for release in rec.get("release-list", []):
+                date_str = release.get("date", "")
+                if date_str:
+                    try:
+                        return int(date_str[:4])
+                    except ValueError:
+                        pass
+    except Exception as e:
+        log.logger.warning("MusicBrainz recording lookup failed for '%s' / '%s': %s", artist, title, str(e))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ID3 tag writing
+# ---------------------------------------------------------------------------
+
+def _write_tags(filepath: str, artist: str | None, title: str | None, album: str | None, track: int | None, year: int | None) -> None:
+    """Writes ID3v1 and ID3v2 tags to an MP3 file using mutagen."""
+    try:
+        try:
+            tags = ID3(filepath)
+        except ID3NoHeaderError:
+            tags = ID3()
+
+        if artist:
+            tags["TPE1"] = TPE1(encoding=3, text=artist)
+        if title:
+            tags["TIT2"] = TIT2(encoding=3, text=title)
+        if album:
+            tags["TALB"] = TALB(encoding=3, text=album)
+        if track is not None:
+            tags["TRCK"] = TRCK(encoding=3, text=str(track))
+        if year is not None:
+            tags["TDRC"] = TDRC(encoding=3, text=str(year))
+
+        # Save ID3v2.3 (most compatible) + ID3v1 header
+        tags.save(filepath, v1=2, v2_version=3)
+        log.logger.info("Tags written: %s | artist=%s title=%s album=%s track=%s year=%s", filepath, artist, title, album, track, year)
+    except Exception as e:
+        log.logger.error("Failed to write tags for %s: %s", filepath, str(e))
+
+
+# ---------------------------------------------------------------------------
+# File timestamp setting
+# ---------------------------------------------------------------------------
+
+def _set_file_date(filepath: str, year: int) -> None:
+    """Sets file creation and modification timestamps to YYYY-01-01 12:00:00."""
+    try:
+        dt = datetime.datetime(year, 1, 1, 12, 0, 0)
+        ts = dt.timestamp()
+        os.utime(filepath, (ts, ts))
+        log.logger.info("Set file date of %s to %d-01-01 12:00", filepath, year)
+    except Exception as e:
+        log.logger.error("Failed to set file date for %s: %s", filepath, str(e))
+
+
+# ---------------------------------------------------------------------------
+# Per-file processing
+# ---------------------------------------------------------------------------
+
+def _process_file(filepath: str, dir_artist: str | None, dir_album: str | None, dir_year: int | None, mb_tracks: list[str], dry_run: bool) -> None:
+    """Processes a single audio file: reads tags, fills in gaps, writes tags."""
+    base = os.path.splitext(os.path.basename(filepath))[0]
+
+    # 1. Parse filename for track#, artist, title
+    fn_track, fn_artist, fn_title = _parse_file_name(base)
+
+    # 2. Read existing tags via mutagen
+    existing_artist, existing_title, existing_album, existing_track, existing_year = None, None, None, None, None
+    try:
+        audio = MP3(filepath)
+        if audio.tags:
+            existing_artist = str(audio.tags.get("TPE1", "")).strip() or None
+            existing_title = str(audio.tags.get("TIT2", "")).strip() or None
+            existing_album = str(audio.tags.get("TALB", "")).strip() or None
+            existing_track_raw = str(audio.tags.get("TRCK", "")).strip()
+            if existing_track_raw:
+                try:
+                    existing_track = int(existing_track_raw.split("/")[0])
+                except ValueError:
+                    pass
+            existing_year_raw = str(audio.tags.get("TDRC", "")).strip()
+            if existing_year_raw:
+                try:
+                    existing_year = int(existing_year_raw[:4])
+                except ValueError:
+                    pass
+    except Exception as e:
+        log.logger.warning("Could not read tags from %s: %s", filepath, str(e))
+
+    # 3. Resolve final values: prefer existing tag, fall back to filename parse, then directory info
+    artist = existing_artist or fn_artist or dir_artist
+    title = existing_title or fn_title
+    album = existing_album or dir_album
+    track = existing_track or fn_track
+    year = existing_year or dir_year
+
+    # 4. Try to match title against MusicBrainz track list (if album was looked up)
+    if title is None and track is not None and mb_tracks and (track - 1) < len(mb_tracks):
+        title = _sentence_case(mb_tracks[track - 1])
+
+    # 5. MusicBrainz lookup for year if still missing
+    if year is None and artist and album:
+        mb_year, _ = _mb_lookup_release(artist, album)
+        year = mb_year
+    if year is None and artist and title:
+        year = _mb_lookup_track(artist, title)
+
+    # 6. Normalise capitalisation
+    if artist:
+        artist = _title_case(artist)
+    if title:
+        title = _sentence_case(title)
+
+    log.logger.info("File: %s  artist=%s  title=%s  album=%s  track=%s  year=%s", base, artist, title, album, track, year)
+
+    if dry_run:
+        return
+
+    # 7. Write tags
+    _write_tags(filepath, artist, title, album, track, year)
+
+    # 8. Set file timestamp
+    if year:
+        _set_file_date(filepath, year)
+
+
+# ---------------------------------------------------------------------------
+# Per-directory processing
+# ---------------------------------------------------------------------------
+
+def _process_directory(dirpath: str, dry_run: bool) -> None:
+    """Processes all audio files in a single directory."""
+    dir_name = os.path.basename(dirpath)
+    dir_artist, dir_album, dir_year = _parse_dir_name(dir_name)
+    log.logger.info("Directory: %s  →  artist=%s  album=%s  year=%s", dir_name, dir_artist, dir_album, dir_year)
+
+    # MusicBrainz album lookup (once per directory)
+    mb_tracks: list[str] = []
+    if dir_artist and dir_album and dir_year is None:
+        mb_year, mb_tracks = _mb_lookup_release(dir_artist, dir_album)
+        if mb_year and dir_year is None:
+            dir_year = mb_year
+
+    audio_files = sorted(
+        [os.path.join(dirpath, f) for f in os.listdir(dirpath) if fil.is_audio_file(f)],
+        key=lambda p: os.path.basename(p).lower(),
+    )
+    log.logger.info("Found %d audio file(s) in %s", len(audio_files), dirpath)
+
+    for filepath in audio_files:
+        _process_file(filepath, dir_artist, dir_album, dir_year, mb_tracks, dry_run)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    util.init("fix-mp3-meta")
+    parser = argparse.ArgumentParser(description="Fix MP3 metadata tags for a music library")
+    parser.add_argument("-d", "--directory", default=r"E:\Musique", help="Root music directory (default: E:\\Musique)")
+    parser.add_argument("--dry-run", action="store_true", help="Parse and log actions without writing tags or changing timestamps")
+    parser.add_argument("-g", "--debug", required=False, type=int, help="Debug level")
+    args = parser.parse_args()
+
+    if args.debug:
+        util.set_debug_level(args.debug)
+
+    root = args.directory
+    if not os.path.isdir(root):
+        log.logger.error("Directory not found: %s", root)
+        sys.exit(1)
+
+    dry_run = args.dry_run
+    if dry_run:
+        log.logger.info("DRY RUN mode — no files will be modified")
+
+    # Process each immediate subdirectory
+    subdirs = sorted([os.path.join(root, d) for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))])
+    log.logger.info("Processing %d subdirectories under %s", len(subdirs), root)
+
+    for subdir in subdirs:
+        log.logger.info("=== Processing directory: %s ===", subdir)
+        try:
+            _process_directory(subdir, dry_run)
+        except Exception as e:
+            log.logger.error("Error processing %s: %s", subdir, str(e))
+
+    # Also process audio files directly in the root (if any)
+    root_audio = [os.path.join(root, f) for f in os.listdir(root) if fil.is_audio_file(f)]
+    if root_audio:
+        log.logger.info("Processing %d audio file(s) directly in root", len(root_audio))
+        _process_directory(root, dry_run)
+
+    log.logger.info("Done.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ music_tag
 PyExifTool
 exifread
 librosa
+musicbrainzngs
+mutagen

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     },
     packages=setuptools.find_packages(),
     package_data={"mediatools": ["LICENSE", "media-tools.properties", "black.jpg", "white.jpg", "video-720p.mp4"]},
-    install_requires=["argparse", "datetime", "mp3_tagger", "ffmpeg-python", "ExifRead", "pyexiftool", "jprops", "librosa"],
+    install_requires=["argparse", "datetime", "mp3_tagger", "ffmpeg-python", "ExifRead", "pyexiftool", "jprops", "librosa", "musicbrainzngs", "mutagen"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
@@ -86,6 +86,7 @@ setuptools.setup(
             "audio-concat = mediatools.audioconcat:main",
             "audio-speed = mediatools.audiospeed:main",
             "video-enhance = mediatools.video_enhance:main",
+            "fix-mp3-meta = mediatools.fix_mp3_meta:main",
         ]
     },
     python_requires=">=3.10",

--- a/tests/test_fix_mp3_meta.py
+++ b/tests/test_fix_mp3_meta.py
@@ -282,3 +282,186 @@ def test_process_directory(tmp_path):
         assert str(tags["TALB"]) == "Seal"
         dt = datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(dest, fname)))
         assert dt.year == 1991
+
+
+# ---------------------------------------------------------------------------
+# Guard clauses (empty inputs)
+# ---------------------------------------------------------------------------
+
+def test_mb_lookup_release_no_artist():
+    year, tracks = fix._mb_lookup_release("", "Album")
+    assert year is None
+    assert tracks == []
+
+
+def test_mb_lookup_release_no_album():
+    year, tracks = fix._mb_lookup_release("Artist", "")
+    assert year is None
+    assert tracks == []
+
+
+def test_mb_lookup_track_no_artist():
+    assert fix._mb_lookup_track("", "Track") is None
+
+
+def test_mb_lookup_track_no_title():
+    assert fix._mb_lookup_track("Artist", "") is None
+
+
+# ---------------------------------------------------------------------------
+# ValueError branches in MusicBrainz date parsing
+# ---------------------------------------------------------------------------
+
+def test_mb_lookup_release_invalid_date():
+    """Non-numeric date string in release should be handled gracefully."""
+    mock_result = {"release-list": [{"id": "abc", "date": "unknown"}]}
+    mock_full = {"release": {"medium-list": []}}
+    with patch("musicbrainzngs.search_releases", return_value=mock_result), \
+         patch("musicbrainzngs.get_release_by_id", return_value=mock_full):
+        year, tracks = fix._mb_lookup_release("Artist", "Album")
+    assert year is None
+    assert tracks == []
+
+
+def test_mb_lookup_track_invalid_date():
+    """Non-numeric date in recording release should be skipped without crash."""
+    mock_result = {"recording-list": [{"release-list": [{"date": "bad-date"}]}]}
+    with patch("musicbrainzngs.search_recordings", return_value=mock_result):
+        year = fix._mb_lookup_track("Artist", "Track")
+    assert year is None
+
+
+# ---------------------------------------------------------------------------
+# Exception handler in _write_tags (ID3NoHeaderError and general exception)
+# ---------------------------------------------------------------------------
+
+def test_write_tags_no_existing_id3_header(tmp_path):
+    """Writing tags to a file that has no ID3 header should not raise."""
+    bare = str(tmp_path / "bare.mp3")
+    shutil.copy(FIXTURE_MP3, bare)
+    from mutagen.id3 import ID3NoHeaderError
+    with patch("mediatools.fix_mp3_meta.ID3", side_effect=[ID3NoHeaderError, ID3()]):
+        fix._write_tags(bare, artist="A", title="T", album="Al", track=1, year=2000)
+
+
+def test_write_tags_exception_is_swallowed(tmp_path):
+    """An exception during tag save should be logged, not propagated."""
+    bad_path = str(tmp_path / "no_such.mp3")
+    fix._write_tags(bad_path, artist="A", title="T", album="Al", track=1, year=2000)
+
+
+# ---------------------------------------------------------------------------
+# Exception handler in _set_file_date
+# ---------------------------------------------------------------------------
+
+def test_set_file_date_exception_is_swallowed(tmp_mp3):
+    with patch("os.utime", side_effect=OSError("permission denied")):
+        fix._set_file_date(tmp_mp3, 2000)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# ValueError branches in _process_file tag reading
+# ---------------------------------------------------------------------------
+
+def test_process_file_non_numeric_track_tag(tmp_path):
+    """A non-numeric TRCK tag must not crash _process_file."""
+    from mutagen.id3 import TRCK, TDRC
+    dest = str(tmp_path / "track.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    tags = ID3(dest)
+    tags["TRCK"] = TRCK(encoding=3, text="not-a-number")
+    tags["TDRC"] = TDRC(encoding=3, text="not-a-year")
+    tags.save(dest)
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_file(dest, dir_artist="Artist", dir_album="Album", dir_year=2001, mb_tracks=[], dry_run=False)
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz year lookup triggered from _process_file when year is unknown
+# ---------------------------------------------------------------------------
+
+def test_process_file_mb_year_lookup_from_album(tmp_path):
+    """When dir_year is None and existing year tag is absent, year is fetched via MB album lookup."""
+    dest = str(tmp_path / "song.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    tags = ID3(dest)
+    tags.delall("TDRC")
+    tags.save(dest)
+    mock_release = {"release-list": [{"id": "x", "date": "1991"}]}
+    mock_full = {"release": {"medium-list": []}}
+    with patch("musicbrainzngs.search_releases", return_value=mock_release), \
+         patch("musicbrainzngs.get_release_by_id", return_value=mock_full), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_file(dest, dir_artist="Seal", dir_album="Seal", dir_year=None, mb_tracks=[], dry_run=False)
+    dt = datetime.datetime.fromtimestamp(os.path.getmtime(dest))
+    assert dt.year == 1991
+
+
+def test_process_file_mb_year_lookup_from_track(tmp_path):
+    """When album MB lookup yields no year, per-track recording lookup is used."""
+    dest = str(tmp_path / "song.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    tags = ID3(dest)
+    tags.delall("TDRC")
+    tags.save(dest)
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": [{"release-list": [{"date": "1991"}]}]}):
+        fix._process_file(dest, dir_artist="Seal", dir_album="Seal", dir_year=None, mb_tracks=[], dry_run=False)
+    dt = datetime.datetime.fromtimestamp(os.path.getmtime(dest))
+    assert dt.year == 1991
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz album lookup triggered from _process_directory when year unknown
+# ---------------------------------------------------------------------------
+
+def test_process_directory_mb_album_lookup(tmp_path):
+    """_process_directory fires MB lookup when directory name has no year."""
+    dest = str(tmp_path / "Seal - Seal")  # no year in dir name
+    os.makedirs(dest)
+    shutil.copy(FIXTURE_MP3, os.path.join(dest, "01 - Crazy.mp3"))
+    tags = ID3(os.path.join(dest, "01 - Crazy.mp3"))
+    tags.delall("TDRC")
+    tags.save(os.path.join(dest, "01 - Crazy.mp3"))
+    mock_release = {"release-list": [{"id": "x", "date": "1991"}]}
+    mock_full = {"release": {"medium-list": []}}
+    with patch("musicbrainzngs.search_releases", return_value=mock_release), \
+         patch("musicbrainzngs.get_release_by_id", return_value=mock_full), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_directory(dest, dry_run=False)
+    dt = datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(dest, "01 - Crazy.mp3")))
+    assert dt.year == 1991
+
+
+# ---------------------------------------------------------------------------
+# main() entry point
+# ---------------------------------------------------------------------------
+
+def test_main_nonexistent_directory():
+    """main() exits with code 1 when the directory does not exist."""
+    with patch("sys.argv", ["fix-mp3-meta", "-d", "/nonexistent_path_xyz"]):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 1
+
+
+def test_main_empty_directory(tmp_path):
+    """main() exits with code 0 for an existing empty directory."""
+    with patch("sys.argv", ["fix-mp3-meta", "-d", str(tmp_path)]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+
+
+def test_main_dry_run(tmp_path):
+    """main() --dry-run exits 0 and does not write any files."""
+    shutil.copy(FIXTURE_MP3, str(tmp_path / "song.mp3"))
+    with patch("sys.argv", ["fix-mp3-meta", "-d", str(tmp_path), "--dry-run"]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0

--- a/tests/test_fix_mp3_meta.py
+++ b/tests/test_fix_mp3_meta.py
@@ -1,0 +1,284 @@
+#!python3
+#
+# media-tools
+# Copyright (C) 2019-2024 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+import os
+import shutil
+import datetime
+from unittest.mock import patch, MagicMock
+import pytest
+
+from mutagen.id3 import ID3
+from mutagen.mp3 import MP3
+
+import mediatools.fix_mp3_meta as fix
+
+FIXTURE_MP3 = os.path.join("it", "seal.mp3")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_mp3(tmp_path):
+    """Copy the fixture MP3 to a temporary location so tests can mutate it."""
+    dest = str(tmp_path / "test.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Capitalisation helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("the beatles", "The Beatles"),
+    ("pink floyd", "Pink Floyd"),
+    ("ACDC", "Acdc"),
+    ("", ""),
+    ("single", "Single"),
+    ("multiple   spaces", "Multiple Spaces"),  # split() collapses runs of whitespace
+])
+def test_title_case(text, expected):
+    assert fix._title_case(text) == expected
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("come together", "Come together"),
+    ("COME TOGETHER", "Come together"),  # sentence_case lowercases rest of string
+    ("hello world", "Hello world"),
+    ("", ""),
+    ("a", "A"),
+])
+def test_sentence_case(text, expected):
+    assert fix._sentence_case(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# Directory name parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dir_name,exp_artist,exp_album,exp_year", [
+    ("The Beatles - Abbey Road", "The Beatles", "Abbey Road", None),
+    ("Pink Floyd - The Wall (1979)", "Pink Floyd", "The Wall", 1979),
+    ("Pink Floyd - The Wall [1979]", "Pink Floyd", "The Wall", 1979),
+    ("Seal", "Seal", None, None),
+    ("the rolling stones - exile on main st", "The Rolling Stones", "exile on main st", None),
+])
+def test_parse_dir_name(dir_name, exp_artist, exp_album, exp_year):
+    artist, album, year = fix._parse_dir_name(dir_name)
+    assert artist == exp_artist
+    assert album == exp_album
+    assert year == exp_year
+
+
+# ---------------------------------------------------------------------------
+# Filename parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("base_name,exp_track,exp_artist,exp_title", [
+    # Bare title
+    ("Come Together", None, None, "Come together"),
+    # Artist - Title
+    ("The Beatles - Come Together", None, "The Beatles", "Come together"),
+    # Track - Title
+    ("01 - Come Together", 1, None, "Come together"),
+    ("03. Come Together", 3, None, "Come together"),
+    ("(02) Come Together", 2, None, "Come together"),
+    # Track - Artist - Title
+    ("04 - The Beatles - Come Together", 4, "The Beatles", "Come together"),
+    # Two-digit track
+    ("12 - Hey Jude", 12, None, "Hey jude"),
+])
+def test_parse_file_name(base_name, exp_track, exp_artist, exp_title):
+    track, artist, title = fix._parse_file_name(base_name)
+    assert track == exp_track
+    assert artist == exp_artist
+    assert title == exp_title
+
+
+# ---------------------------------------------------------------------------
+# Tag writing
+# ---------------------------------------------------------------------------
+
+def test_write_tags_creates_id3_header(tmp_mp3):
+    fix._write_tags(tmp_mp3, artist="Test Artist", title="Test title", album="Test Album", track=3, year=2001)
+    tags = ID3(tmp_mp3)
+    assert str(tags["TPE1"]) == "Test Artist"
+    assert str(tags["TIT2"]) == "Test title"
+    assert str(tags["TALB"]) == "Test Album"
+    assert str(tags["TRCK"]) == "3"
+    assert str(tags["TDRC"]) == "2001"
+
+
+def test_write_tags_partial(tmp_mp3):
+    """write_tags with some None fields should not crash and only set provided tags."""
+    fix._write_tags(tmp_mp3, artist="Solo Artist", title=None, album=None, track=None, year=None)
+    tags = ID3(tmp_mp3)
+    assert str(tags["TPE1"]) == "Solo Artist"
+
+
+def test_write_tags_id3v1_present(tmp_mp3):
+    """mutagen save with v1=2 should write both v1 and v2 headers."""
+    fix._write_tags(tmp_mp3, artist="Artist", title="Title", album="Album", track=1, year=1999)
+    audio = MP3(tmp_mp3)
+    assert audio.tags is not None
+
+
+# ---------------------------------------------------------------------------
+# File timestamp setting
+# ---------------------------------------------------------------------------
+
+def test_set_file_date(tmp_mp3):
+    fix._set_file_date(tmp_mp3, 1991)
+    mtime = os.path.getmtime(tmp_mp3)
+    dt = datetime.datetime.fromtimestamp(mtime)
+    assert dt.year == 1991
+    assert dt.month == 1
+    assert dt.day == 1
+    assert dt.hour == 12
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz lookups (mocked to avoid network calls)
+# ---------------------------------------------------------------------------
+
+def test_mb_lookup_release_returns_year_and_tracks():
+    mock_result = {
+        "release-list": [{"id": "abc-123", "date": "1991-05-06"}]
+    }
+    mock_full = {
+        "release": {
+            "medium-list": [
+                {
+                    "track-list": [
+                        {"recording": {"title": "Crazy"}},
+                        {"recording": {"title": "Future Love Paradise"}},
+                    ]
+                }
+            ]
+        }
+    }
+    with patch("musicbrainzngs.search_releases", return_value=mock_result), \
+         patch("musicbrainzngs.get_release_by_id", return_value=mock_full):
+        year, tracks = fix._mb_lookup_release("Seal", "Seal")
+    assert year == 1991
+    assert tracks == ["Crazy", "Future Love Paradise"]
+
+
+def test_mb_lookup_release_empty_result():
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}):
+        year, tracks = fix._mb_lookup_release("Unknown", "Unknown Album")
+    assert year is None
+    assert tracks == []
+
+
+def test_mb_lookup_release_network_error():
+    with patch("musicbrainzngs.search_releases", side_effect=Exception("network error")):
+        year, tracks = fix._mb_lookup_release("Artist", "Album")
+    assert year is None
+    assert tracks == []
+
+
+def test_mb_lookup_track_returns_year():
+    mock_result = {
+        "recording-list": [
+            {"release-list": [{"date": "1991-05-06"}]}
+        ]
+    }
+    with patch("musicbrainzngs.search_recordings", return_value=mock_result):
+        year = fix._mb_lookup_track("Seal", "Crazy")
+    assert year == 1991
+
+
+def test_mb_lookup_track_no_result():
+    with patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        year = fix._mb_lookup_track("Unknown", "Unknown Track")
+    assert year is None
+
+
+def test_mb_lookup_track_network_error():
+    with patch("musicbrainzngs.search_recordings", side_effect=Exception("timeout")):
+        year = fix._mb_lookup_track("Artist", "Track")
+    assert year is None
+
+
+# ---------------------------------------------------------------------------
+# process_file — dry run (no writes) and live run
+# ---------------------------------------------------------------------------
+
+def test_process_file_dry_run_does_not_modify_file(tmp_mp3):
+    mtime_before = os.path.getmtime(tmp_mp3)
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_file(tmp_mp3, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=[], dry_run=True)
+    mtime_after = os.path.getmtime(tmp_mp3)
+    assert mtime_before == mtime_after
+
+
+def test_process_file_writes_tags_and_date(tmp_mp3):
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_file(tmp_mp3, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=[], dry_run=False)
+    tags = ID3(tmp_mp3)
+    assert str(tags["TPE1"]) == "Seal"
+    dt = datetime.datetime.fromtimestamp(os.path.getmtime(tmp_mp3))
+    assert dt.year == 1991
+
+
+def test_process_file_uses_mb_tracks_for_title(tmp_path):
+    """When filename has only a track number (no title) and no title tag, mb_tracks fills the title."""
+    mb_tracks = ["Crazy", "Future Love Paradise", "Wild"]
+    # File name "01.mp3" → track=1, title=None from filename
+    track1_path = str(tmp_path / "01.mp3")
+    shutil.copy(FIXTURE_MP3, track1_path)
+    # Clear existing title and track tags so filename-parsed track=1 and mb_tracks fallback are used
+    tags = ID3(track1_path)
+    tags.delall("TIT2")
+    tags.delall("TRCK")
+    tags.save(track1_path)
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_file(track1_path, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=mb_tracks, dry_run=False)
+    result_tags = ID3(track1_path)
+    assert str(result_tags["TIT2"]) == "Crazy"
+
+
+# ---------------------------------------------------------------------------
+# process_directory — integration
+# ---------------------------------------------------------------------------
+
+def test_process_directory(tmp_path):
+    """process_directory must process all MP3s in a folder without raising."""
+    dest = str(tmp_path / "Seal - Seal (1991)")
+    os.makedirs(dest)
+    shutil.copy(FIXTURE_MP3, os.path.join(dest, "01 - Crazy.mp3"))
+    shutil.copy(FIXTURE_MP3, os.path.join(dest, "02 - Future Love Paradise.mp3"))
+    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.get_release_by_id", return_value={"release": {"medium-list": []}}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        fix._process_directory(dest, dry_run=False)
+    for fname in ("01 - Crazy.mp3", "02 - Future Love Paradise.mp3"):
+        tags = ID3(os.path.join(dest, fname))
+        assert str(tags["TPE1"]) == "Seal"
+        assert str(tags["TALB"]) == "Seal"
+        dt = datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(dest, fname)))
+        assert dt.year == 1991


### PR DESCRIPTION
## Summary

- Adds `mediatools/fix_mp3_meta.py` — a new `fix-mp3-meta` CLI tool that processes a music library directory and repairs ID3 metadata in batch
- Infers artist, title, album, track number, and year from filenames (`Artist - Title.mp3`) and directory names (`Artist - Album` pattern)
- Looks up missing release years on MusicBrainz (album-level first, then per-recording fallback)
- Normalises capitalisation: artist → Title Case, track title → Sentence case
- Writes ID3v1 + ID3v2.3 tags via mutagen; sets file timestamps to `YYYY-01-01 12:00:00` when a release year is resolved
- Registers `fix-mp3-meta` as a `console_scripts` entry point in `setup.py`
- Adds `musicbrainzngs` and `mutagen` to `install_requires`

## Test plan

- [ ] Run `fix-mp3-meta --help` to verify CLI loads correctly
- [ ] Run `fix-mp3-meta -d "E:\Musique" --dry-run` and review log output for correct parsing of directory/filename patterns
- [ ] Run without `--dry-run` on a test subdirectory and verify tags with a tag editor (e.g. Mp3tag)
- [ ] Verify ID3v1 and ID3v2 tags are both present after processing
- [ ] Verify file timestamps are updated when a year is resolved
- [ ] Verify MusicBrainz lookup fires for directories where year is unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)