### PR TITLE
fix-mp3-meta: accept file/dir list input and add M4A support

### DIFF
--- a/batch-files/fix-mp3-meta.bat
+++ b/batch-files/fix-mp3-meta.bat
@@ -1,0 +1,23 @@
+::
+:: media-tools
+:: Copyright (C) 2019-2024 Olivier Korach
+:: mailto:olivier.korach AT gmail DOT com
+::
+:: This program is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 3 of the License, or (at your option) any later version.
+::
+:: This program is distributed in the hope that it will be useful,
+:: but WITHOUT ANY WARRANTY; without even the implied warranty of
+:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+:: Lesser General Public License for more details.
+::
+:: You should have received a copy of the GNU Lesser General Public License
+:: along with this program; if not, write to the Free Software Foundation,
+:: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+::
+
+fix-mp3-meta %*
+
+pause

--- a/batch-files/fix-mp3-meta.bat
+++ b/batch-files/fix-mp3-meta.bat
@@ -18,6 +18,6 @@
 :: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ::
 
-fix-mp3-meta %*
+fix-mp3-meta -f %*
 
 pause

--- a/mediatools/fix_mp3_meta.py
+++ b/mediatools/fix_mp3_meta.py
@@ -69,6 +69,7 @@ _ARTIST_TITLE_RE = re.compile(r"^(.+?)\s+-\s+(.+)$")
 # Capitalisation helpers
 # ---------------------------------------------------------------------------
 
+
 def _title_case(text: str) -> str:
     """Every word's first letter uppercase (artist style)."""
     if not text:
@@ -86,6 +87,7 @@ def _sentence_case(text: str) -> str:
 # ---------------------------------------------------------------------------
 # Filename / directory parsing
 # ---------------------------------------------------------------------------
+
 
 def _parse_dir_name(dir_name: str) -> tuple[str | None, str | None, int | None]:
     """Returns (artist, album, year) extracted from a directory base name."""
@@ -108,7 +110,7 @@ def _parse_file_name(base_name: str) -> tuple[int | None, str | None, str | None
     tm = _TRACK_PREFIX_RE.match(base_name)
     if tm:
         track = int(tm.group(1))
-        rest = base_name[tm.end():].strip()
+        rest = base_name[tm.end() :].strip()
     else:
         rest = base_name.strip()
 
@@ -126,6 +128,7 @@ def _parse_file_name(base_name: str) -> tuple[int | None, str | None, str | None
 # ---------------------------------------------------------------------------
 # MusicBrainz lookup
 # ---------------------------------------------------------------------------
+
 
 def _mb_lookup_release(artist: str, album: str) -> tuple[int | None, list[str]]:
     """Returns (year, [track_title, ...]) from MusicBrainz for the best-matching release."""
@@ -181,6 +184,7 @@ def _mb_lookup_track(artist: str, title: str) -> int | None:
 # ID3 tag writing
 # ---------------------------------------------------------------------------
 
+
 def _write_tags(filepath: str, artist: str | None, title: str | None, album: str | None, track: int | None, year: int | None) -> None:
     """Writes ID3v1 and ID3v2 tags to an MP3 file using mutagen."""
     try:
@@ -211,6 +215,7 @@ def _write_tags(filepath: str, artist: str | None, title: str | None, album: str
 # File timestamp setting
 # ---------------------------------------------------------------------------
 
+
 def _set_file_date(filepath: str, year: int) -> None:
     """Sets file creation and modification timestamps to YYYY-01-01 12:00:00."""
     try:
@@ -225,6 +230,7 @@ def _set_file_date(filepath: str, year: int) -> None:
 # ---------------------------------------------------------------------------
 # Per-file processing
 # ---------------------------------------------------------------------------
+
 
 def _process_file(filepath: str, dir_artist: str | None, dir_album: str | None, dir_year: int | None, mb_tracks: list[str], dry_run: bool) -> None:
     """Processes a single audio file: reads tags, fills in gaps, writes tags."""
@@ -297,6 +303,7 @@ def _process_file(filepath: str, dir_artist: str | None, dir_album: str | None, 
 # Per-directory processing
 # ---------------------------------------------------------------------------
 
+
 def _process_directory(dirpath: str, dry_run: bool) -> None:
     """Processes all audio files in a single directory."""
     dir_name = os.path.basename(dirpath)
@@ -324,10 +331,11 @@ def _process_directory(dirpath: str, dry_run: bool) -> None:
 # Main entry point
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     util.init("fix-mp3-meta")
     parser = argparse.ArgumentParser(description="Fix MP3 metadata tags for a music library")
-    parser.add_argument("-d", "--directory", default=r"E:\Musique", help="Root music directory (default: E:\\Musique)")
+    parser.add_argument("-f", "--files", nargs="+", help="Files and/or directories to process (default: E:\\Musique)")
     parser.add_argument("--dry-run", action="store_true", help="Parse and log actions without writing tags or changing timestamps")
     parser.add_argument("-g", "--debug", required=False, type=int, help="Debug level")
     args = parser.parse_args()
@@ -335,31 +343,58 @@ def main() -> None:
     if args.debug:
         util.set_debug_level(args.debug)
 
-    root = args.directory
-    if not os.path.isdir(root):
-        log.logger.error("Directory not found: %s", root)
-        sys.exit(1)
-
+    inputs = args.files if args.files else [r"E:\Musique"]
     dry_run = args.dry_run
     if dry_run:
         log.logger.info("DRY RUN mode — no files will be modified")
 
-    # Process each immediate subdirectory
-    subdirs = sorted([os.path.join(root, d) for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))])
-    log.logger.info("Processing %d subdirectories under %s", len(subdirs), root)
+    # Collect directories to process and loose audio files grouped by their parent directory
+    dirs_to_process: list[str] = []
+    files_by_dir: dict[str, list[str]] = {}
 
-    for subdir in subdirs:
-        log.logger.info("=== Processing directory: %s ===", subdir)
-        try:
-            _process_directory(subdir, dry_run)
-        except Exception as e:
-            log.logger.error("Error processing %s: %s", subdir, str(e))
+    for entry in inputs:
+        entry = os.path.abspath(entry)
+        if os.path.isdir(entry):
+            dirs_to_process.append(entry)
+        elif fil.is_audio_file(entry):
+            parent = os.path.dirname(entry)
+            files_by_dir.setdefault(parent, []).append(entry)
+        else:
+            log.logger.warning("Skipping %s: not a directory or audio file", entry)
 
-    # Also process audio files directly in the root (if any)
-    root_audio = [os.path.join(root, f) for f in os.listdir(root) if fil.is_audio_file(f)]
-    if root_audio:
-        log.logger.info("Processing %d audio file(s) directly in root", len(root_audio))
-        _process_directory(root, dry_run)
+    # For directories: process each immediate subdirectory, then any audio files at the root level
+    for root in sorted(dirs_to_process):
+        if not os.path.isdir(root):
+            log.logger.error("Directory not found: %s", root)
+            continue
+        subdirs = sorted([os.path.join(root, d) for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))])
+        root_audio = [os.path.join(root, f) for f in os.listdir(root) if fil.is_audio_file(f)]
+        if subdirs:
+            log.logger.info("Processing %d subdirectories under %s", len(subdirs), root)
+            for subdir in subdirs:
+                log.logger.info("=== Processing directory: %s ===", subdir)
+                try:
+                    _process_directory(subdir, dry_run)
+                except Exception as e:
+                    log.logger.error("Error processing %s: %s", subdir, str(e))
+        if root_audio:
+            log.logger.info("Processing %d audio file(s) directly in %s", len(root_audio), root)
+            _process_directory(root, dry_run)
+
+    # For individual files: process them with the context of their parent directory
+    for parent, file_list in sorted(files_by_dir.items()):
+        dir_artist, dir_album, dir_year = _parse_dir_name(os.path.basename(parent))
+        mb_tracks: list[str] = []
+        if dir_artist and dir_album and dir_year is None:
+            mb_year, mb_tracks = _mb_lookup_release(dir_artist, dir_album)
+            if mb_year:
+                dir_year = mb_year
+        log.logger.info("Processing %d file(s) from %s", len(file_list), parent)
+        for filepath in sorted(file_list):
+            try:
+                _process_file(filepath, dir_artist, dir_album, dir_year, mb_tracks, dry_run)
+            except Exception as e:
+                log.logger.error("Error processing %s: %s", filepath, str(e))
 
     log.logger.info("Done.")
     sys.exit(0)

--- a/mediatools/fix_mp3_meta.py
+++ b/mediatools/fix_mp3_meta.py
@@ -44,6 +44,9 @@ import musicbrainzngs
 import mutagen
 from mutagen.id3 import ID3, TIT2, TPE1, TALB, TRCK, TDRC, ID3NoHeaderError
 from mutagen.mp3 import MP3
+from mutagen.mp4 import MP4
+
+_M4A_TAG_MAP = {"artist": "©ART", "title": "©nam", "album": "©alb", "year": "©day", "track": "trkn"}
 
 from mediatools import log
 import mediatools.utilities as util
@@ -181,31 +184,94 @@ def _mb_lookup_track(artist: str, title: str) -> int | None:
 
 
 # ---------------------------------------------------------------------------
-# ID3 tag writing
+# Tag reading / writing (MP3 via ID3, M4A via MP4 atoms)
 # ---------------------------------------------------------------------------
 
 
-def _write_tags(filepath: str, artist: str | None, title: str | None, album: str | None, track: int | None, year: int | None) -> None:
-    """Writes ID3v1 and ID3v2 tags to an MP3 file using mutagen."""
+def _is_m4a(filepath: str) -> bool:
+    return fil.extension(filepath).lower() in ("m4a", "aac")
+
+
+def _read_existing_tags(filepath: str) -> tuple[str | None, str | None, str | None, int | None, int | None]:
+    """Returns (artist, title, album, track, year) from existing file tags."""
+    artist = title = album = None
+    track = year = None
     try:
-        try:
-            tags = ID3(filepath)
-        except ID3NoHeaderError:
-            tags = ID3()
+        if _is_m4a(filepath):
+            tags = MP4(filepath).tags or {}
+            artist = (tags.get(_M4A_TAG_MAP["artist"], [None])[0] or "").strip() or None
+            title = (tags.get(_M4A_TAG_MAP["title"], [None])[0] or "").strip() or None
+            album = (tags.get(_M4A_TAG_MAP["album"], [None])[0] or "").strip() or None
+            trkn = tags.get(_M4A_TAG_MAP["track"], None)
+            if trkn:
+                try:
+                    track = int(trkn[0][0])
+                except (ValueError, IndexError, TypeError):
+                    pass
+            day = (tags.get(_M4A_TAG_MAP["year"], [None])[0] or "").strip()
+            if day:
+                try:
+                    year = int(day[:4])
+                except ValueError:
+                    pass
+        else:
+            audio = MP3(filepath)
+            if audio.tags:
+                artist = str(audio.tags.get("TPE1", "")).strip() or None
+                title = str(audio.tags.get("TIT2", "")).strip() or None
+                album = str(audio.tags.get("TALB", "")).strip() or None
+                trk_raw = str(audio.tags.get("TRCK", "")).strip()
+                if trk_raw:
+                    try:
+                        track = int(trk_raw.split("/")[0])
+                    except ValueError:
+                        pass
+                yr_raw = str(audio.tags.get("TDRC", "")).strip()
+                if yr_raw:
+                    try:
+                        year = int(yr_raw[:4])
+                    except ValueError:
+                        pass
+    except Exception as e:
+        log.logger.warning("Could not read tags from %s: %s", filepath, str(e))
+    return artist, title, album, track, year
 
-        if artist:
-            tags["TPE1"] = TPE1(encoding=3, text=artist)
-        if title:
-            tags["TIT2"] = TIT2(encoding=3, text=title)
-        if album:
-            tags["TALB"] = TALB(encoding=3, text=album)
-        if track is not None:
-            tags["TRCK"] = TRCK(encoding=3, text=str(track))
-        if year is not None:
-            tags["TDRC"] = TDRC(encoding=3, text=str(year))
 
-        # Save ID3v2.3 (most compatible) + ID3v1 header
-        tags.save(filepath, v1=2, v2_version=3)
+def _write_tags(filepath: str, artist: str | None, title: str | None, album: str | None, track: int | None, year: int | None) -> None:
+    """Writes tags to an audio file — ID3v1+v2 for MP3, iTunes atoms for M4A."""
+    try:
+        if _is_m4a(filepath):
+            audio = MP4(filepath)
+            if audio.tags is None:
+                audio.add_tags()
+            if artist:
+                audio.tags[_M4A_TAG_MAP["artist"]] = [artist]
+            if title:
+                audio.tags[_M4A_TAG_MAP["title"]] = [title]
+            if album:
+                audio.tags[_M4A_TAG_MAP["album"]] = [album]
+            if track is not None:
+                audio.tags[_M4A_TAG_MAP["track"]] = [(track, 0)]
+            if year is not None:
+                audio.tags[_M4A_TAG_MAP["year"]] = [str(year)]
+            audio.save()
+        else:
+            try:
+                tags = ID3(filepath)
+            except ID3NoHeaderError:
+                tags = ID3()
+            if artist:
+                tags["TPE1"] = TPE1(encoding=3, text=artist)
+            if title:
+                tags["TIT2"] = TIT2(encoding=3, text=title)
+            if album:
+                tags["TALB"] = TALB(encoding=3, text=album)
+            if track is not None:
+                tags["TRCK"] = TRCK(encoding=3, text=str(track))
+            if year is not None:
+                tags["TDRC"] = TDRC(encoding=3, text=str(year))
+            # Save ID3v2.3 (most compatible) + ID3v1 header
+            tags.save(filepath, v1=2, v2_version=3)
         log.logger.info("Tags written: %s | artist=%s title=%s album=%s track=%s year=%s", filepath, artist, title, album, track, year)
     except Exception as e:
         log.logger.error("Failed to write tags for %s: %s", filepath, str(e))
@@ -239,28 +305,8 @@ def _process_file(filepath: str, dir_artist: str | None, dir_album: str | None, 
     # 1. Parse filename for track#, artist, title
     fn_track, fn_artist, fn_title = _parse_file_name(base)
 
-    # 2. Read existing tags via mutagen
-    existing_artist, existing_title, existing_album, existing_track, existing_year = None, None, None, None, None
-    try:
-        audio = MP3(filepath)
-        if audio.tags:
-            existing_artist = str(audio.tags.get("TPE1", "")).strip() or None
-            existing_title = str(audio.tags.get("TIT2", "")).strip() or None
-            existing_album = str(audio.tags.get("TALB", "")).strip() or None
-            existing_track_raw = str(audio.tags.get("TRCK", "")).strip()
-            if existing_track_raw:
-                try:
-                    existing_track = int(existing_track_raw.split("/")[0])
-                except ValueError:
-                    pass
-            existing_year_raw = str(audio.tags.get("TDRC", "")).strip()
-            if existing_year_raw:
-                try:
-                    existing_year = int(existing_year_raw[:4])
-                except ValueError:
-                    pass
-    except Exception as e:
-        log.logger.warning("Could not read tags from %s: %s", filepath, str(e))
+    # 2. Read existing tags via mutagen (handles both MP3 and M4A)
+    existing_artist, existing_title, existing_album, existing_track, existing_year = _read_existing_tags(filepath)
 
     # 3. Resolve final values: prefer existing tag, fall back to filename parse, then directory info
     artist = existing_artist or fn_artist or dir_artist

--- a/tests/test_fix_mp3_meta.py
+++ b/tests/test_fix_mp3_meta.py
@@ -534,3 +534,155 @@ def test_main_mixed_files_and_dirs(tmp_path):
         with pytest.raises(SystemExit) as exc:
             fix.main()
     assert exc.value.code == 0
+
+
+def test_main_with_debug_flag(tmp_path):
+    """main() -g flag sets debug level without crashing."""
+    with patch("sys.argv", ["fix-mp3-meta", "-f", str(tmp_path), "-g", "5"]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+
+
+def test_main_with_subdirectories(tmp_path):
+    """main() processes subdirectories when root dir contains them."""
+    subdir = tmp_path / "Seal - Seal (1991)"
+    subdir.mkdir()
+    shutil.copy(FIXTURE_MP3, str(subdir / "01 - Crazy.mp3"))
+    with patch("sys.argv", ["fix-mp3-meta", "-f", str(tmp_path)]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+
+
+def test_main_individual_files_mb_lookup(tmp_path):
+    """When individual files are in an Artist-Album dir, MB lookup fires for the album."""
+    parent = tmp_path / "Seal - Seal"
+    parent.mkdir()
+    src = str(parent / "01.mp3")
+    shutil.copy(FIXTURE_MP3, src)
+    tags = ID3(src)
+    tags.delall("TDRC")
+    tags.save(src)
+    mock_release = {"release-list": [{"id": "x", "date": "1991"}]}
+    mock_full = {"release": {"medium-list": []}}
+    with patch("sys.argv", ["fix-mp3-meta", "-f", src]), \
+         patch("musicbrainzngs.search_releases", return_value=mock_release), \
+         patch("musicbrainzngs.get_release_by_id", return_value=mock_full), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+    dt = datetime.datetime.fromtimestamp(os.path.getmtime(src))
+    assert dt.year == 1991
+
+
+def test_main_skips_non_audio_file(tmp_path):
+    """main() logs a warning and skips entries that are not audio files or directories."""
+    txt_file = str(tmp_path / "readme.txt")
+    with open(txt_file, "w") as f:
+        f.write("not audio")
+    with patch("sys.argv", ["fix-mp3-meta", "-f", txt_file]):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# M4A / AAC tag support
+# ---------------------------------------------------------------------------
+
+def test_is_m4a():
+    assert fix._is_m4a("song.m4a") is True
+    assert fix._is_m4a("song.aac") is True
+    assert fix._is_m4a("song.mp3") is False
+    assert fix._is_m4a("song.ogg") is False
+
+
+def _make_mp4_mock(artist="Seal", title="Crazy", album="Seal", track=[(3, 0)], year="1991"):
+    """Build a MagicMock that behaves like a mutagen MP4 object."""
+    tags = {
+        "©ART": [artist],
+        "©nam": [title],
+        "©alb": [album],
+        "trkn": track,
+        "©day": [year],
+    }
+    mock_audio = MagicMock()
+    mock_audio.tags = tags
+    return mock_audio
+
+
+def test_read_existing_tags_m4a_full():
+    """_read_existing_tags reads all fields from an M4A file."""
+    with patch("mediatools.fix_mp3_meta.MP4", return_value=_make_mp4_mock()):
+        artist, title, album, track, year = fix._read_existing_tags("song.m4a")
+    assert artist == "Seal"
+    assert title == "Crazy"
+    assert album == "Seal"
+    assert track == 3
+    assert year == 1991
+
+
+def test_read_existing_tags_m4a_no_tags():
+    """_read_existing_tags handles an M4A with no tags gracefully."""
+    mock_audio = MagicMock()
+    mock_audio.tags = None
+    with patch("mediatools.fix_mp3_meta.MP4", return_value=mock_audio):
+        artist, title, album, track, year = fix._read_existing_tags("song.m4a")
+    assert artist is None and title is None and album is None
+    assert track is None and year is None
+
+
+def test_read_existing_tags_m4a_invalid_track():
+    """Non-numeric trkn in M4A is skipped without crash."""
+    with patch("mediatools.fix_mp3_meta.MP4", return_value=_make_mp4_mock(track=[("bad", 0)])):
+        _, _, _, track, _ = fix._read_existing_tags("song.m4a")
+    assert track is None
+
+
+def test_read_existing_tags_m4a_invalid_year():
+    """Non-numeric year in M4A is skipped without crash."""
+    with patch("mediatools.fix_mp3_meta.MP4", return_value=_make_mp4_mock(year="unknown")):
+        _, _, _, _, year = fix._read_existing_tags("song.m4a")
+    assert year is None
+
+
+def test_write_tags_m4a():
+    """_write_tags writes iTunes atoms to an M4A file."""
+    mock_audio = _make_mp4_mock()
+    with patch("mediatools.fix_mp3_meta.MP4", return_value=mock_audio):
+        fix._write_tags("song.m4a", artist="Seal", title="Crazy", album="Seal", track=3, year=1991)
+    mock_audio.save.assert_called_once()
+    assert mock_audio.tags["©ART"] == ["Seal"]
+    assert mock_audio.tags["©nam"] == ["Crazy"]
+    assert mock_audio.tags["©alb"] == ["Seal"]
+    assert mock_audio.tags["trkn"] == [(3, 0)]
+    assert mock_audio.tags["©day"] == ["1991"]
+
+
+def test_write_tags_m4a_no_existing_tags():
+    """_write_tags calls add_tags() when M4A has no tag container."""
+    mock_audio = MagicMock()
+    mock_audio.tags = None
+    with patch("mediatools.fix_mp3_meta.MP4", return_value=mock_audio):
+        fix._write_tags("song.m4a", artist="A", title="T", album="Al", track=1, year=2000)
+    mock_audio.add_tags.assert_called_once()
+
+
+def test_process_file_m4a(tmp_path):
+    """_process_file correctly handles an M4A file end-to-end."""
+    m4a_path = str(tmp_path / "01 - Crazy.m4a")
+    mock_audio = _make_mp4_mock(track=[(1, 0)], year="")
+    mock_write = MagicMock()
+    mock_write.tags = {}
+    with patch("mediatools.fix_mp3_meta.MP4", side_effect=[mock_audio, mock_write]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}), \
+         patch("os.utime"):
+        fix._process_file(m4a_path, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=[], dry_run=False)
+    mock_write.save.assert_called_once()

--- a/tests/test_fix_mp3_meta.py
+++ b/tests/test_fix_mp3_meta.py
@@ -37,6 +37,7 @@ FIXTURE_MP3 = os.path.join("it", "seal.mp3")
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def tmp_mp3(tmp_path):
     """Copy the fixture MP3 to a temporary location so tests can mutate it."""
@@ -49,25 +50,32 @@ def tmp_mp3(tmp_path):
 # Capitalisation helpers
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("text,expected", [
-    ("the beatles", "The Beatles"),
-    ("pink floyd", "Pink Floyd"),
-    ("ACDC", "Acdc"),
-    ("", ""),
-    ("single", "Single"),
-    ("multiple   spaces", "Multiple Spaces"),  # split() collapses runs of whitespace
-])
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("the beatles", "The Beatles"),
+        ("pink floyd", "Pink Floyd"),
+        ("ACDC", "Acdc"),
+        ("", ""),
+        ("single", "Single"),
+        ("multiple   spaces", "Multiple Spaces"),  # split() collapses runs of whitespace
+    ],
+)
 def test_title_case(text, expected):
     assert fix._title_case(text) == expected
 
 
-@pytest.mark.parametrize("text,expected", [
-    ("come together", "Come together"),
-    ("COME TOGETHER", "Come together"),  # sentence_case lowercases rest of string
-    ("hello world", "Hello world"),
-    ("", ""),
-    ("a", "A"),
-])
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("come together", "Come together"),
+        ("COME TOGETHER", "Come together"),  # sentence_case lowercases rest of string
+        ("hello world", "Hello world"),
+        ("", ""),
+        ("a", "A"),
+    ],
+)
 def test_sentence_case(text, expected):
     assert fix._sentence_case(text) == expected
 
@@ -76,13 +84,17 @@ def test_sentence_case(text, expected):
 # Directory name parsing
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("dir_name,exp_artist,exp_album,exp_year", [
-    ("The Beatles - Abbey Road", "The Beatles", "Abbey Road", None),
-    ("Pink Floyd - The Wall (1979)", "Pink Floyd", "The Wall", 1979),
-    ("Pink Floyd - The Wall [1979]", "Pink Floyd", "The Wall", 1979),
-    ("Seal", "Seal", None, None),
-    ("the rolling stones - exile on main st", "The Rolling Stones", "exile on main st", None),
-])
+
+@pytest.mark.parametrize(
+    "dir_name,exp_artist,exp_album,exp_year",
+    [
+        ("The Beatles - Abbey Road", "The Beatles", "Abbey Road", None),
+        ("Pink Floyd - The Wall (1979)", "Pink Floyd", "The Wall", 1979),
+        ("Pink Floyd - The Wall [1979]", "Pink Floyd", "The Wall", 1979),
+        ("Seal", "Seal", None, None),
+        ("the rolling stones - exile on main st", "The Rolling Stones", "exile on main st", None),
+    ],
+)
 def test_parse_dir_name(dir_name, exp_artist, exp_album, exp_year):
     artist, album, year = fix._parse_dir_name(dir_name)
     assert artist == exp_artist
@@ -94,20 +106,24 @@ def test_parse_dir_name(dir_name, exp_artist, exp_album, exp_year):
 # Filename parsing
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("base_name,exp_track,exp_artist,exp_title", [
-    # Bare title
-    ("Come Together", None, None, "Come together"),
-    # Artist - Title
-    ("The Beatles - Come Together", None, "The Beatles", "Come together"),
-    # Track - Title
-    ("01 - Come Together", 1, None, "Come together"),
-    ("03. Come Together", 3, None, "Come together"),
-    ("(02) Come Together", 2, None, "Come together"),
-    # Track - Artist - Title
-    ("04 - The Beatles - Come Together", 4, "The Beatles", "Come together"),
-    # Two-digit track
-    ("12 - Hey Jude", 12, None, "Hey jude"),
-])
+
+@pytest.mark.parametrize(
+    "base_name,exp_track,exp_artist,exp_title",
+    [
+        # Bare title
+        ("Come Together", None, None, "Come together"),
+        # Artist - Title
+        ("The Beatles - Come Together", None, "The Beatles", "Come together"),
+        # Track - Title
+        ("01 - Come Together", 1, None, "Come together"),
+        ("03. Come Together", 3, None, "Come together"),
+        ("(02) Come Together", 2, None, "Come together"),
+        # Track - Artist - Title
+        ("04 - The Beatles - Come Together", 4, "The Beatles", "Come together"),
+        # Two-digit track
+        ("12 - Hey Jude", 12, None, "Hey jude"),
+    ],
+)
 def test_parse_file_name(base_name, exp_track, exp_artist, exp_title):
     track, artist, title = fix._parse_file_name(base_name)
     assert track == exp_track
@@ -118,6 +134,7 @@ def test_parse_file_name(base_name, exp_track, exp_artist, exp_title):
 # ---------------------------------------------------------------------------
 # Tag writing
 # ---------------------------------------------------------------------------
+
 
 def test_write_tags_creates_id3_header(tmp_mp3):
     fix._write_tags(tmp_mp3, artist="Test Artist", title="Test title", album="Test Album", track=3, year=2001)
@@ -147,6 +164,7 @@ def test_write_tags_id3v1_present(tmp_mp3):
 # File timestamp setting
 # ---------------------------------------------------------------------------
 
+
 def test_set_file_date(tmp_mp3):
     fix._set_file_date(tmp_mp3, 1991)
     mtime = os.path.getmtime(tmp_mp3)
@@ -161,10 +179,9 @@ def test_set_file_date(tmp_mp3):
 # MusicBrainz lookups (mocked to avoid network calls)
 # ---------------------------------------------------------------------------
 
+
 def test_mb_lookup_release_returns_year_and_tracks():
-    mock_result = {
-        "release-list": [{"id": "abc-123", "date": "1991-05-06"}]
-    }
+    mock_result = {"release-list": [{"id": "abc-123", "date": "1991-05-06"}]}
     mock_full = {
         "release": {
             "medium-list": [
@@ -177,8 +194,7 @@ def test_mb_lookup_release_returns_year_and_tracks():
             ]
         }
     }
-    with patch("musicbrainzngs.search_releases", return_value=mock_result), \
-         patch("musicbrainzngs.get_release_by_id", return_value=mock_full):
+    with patch("musicbrainzngs.search_releases", return_value=mock_result), patch("musicbrainzngs.get_release_by_id", return_value=mock_full):
         year, tracks = fix._mb_lookup_release("Seal", "Seal")
     assert year == 1991
     assert tracks == ["Crazy", "Future Love Paradise"]
@@ -199,11 +215,7 @@ def test_mb_lookup_release_network_error():
 
 
 def test_mb_lookup_track_returns_year():
-    mock_result = {
-        "recording-list": [
-            {"release-list": [{"date": "1991-05-06"}]}
-        ]
-    }
+    mock_result = {"recording-list": [{"release-list": [{"date": "1991-05-06"}]}]}
     with patch("musicbrainzngs.search_recordings", return_value=mock_result):
         year = fix._mb_lookup_track("Seal", "Crazy")
     assert year == 1991
@@ -225,18 +237,23 @@ def test_mb_lookup_track_network_error():
 # process_file — dry run (no writes) and live run
 # ---------------------------------------------------------------------------
 
+
 def test_process_file_dry_run_does_not_modify_file(tmp_mp3):
     mtime_before = os.path.getmtime(tmp_mp3)
-    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value={"release-list": []}),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_file(tmp_mp3, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=[], dry_run=True)
     mtime_after = os.path.getmtime(tmp_mp3)
     assert mtime_before == mtime_after
 
 
 def test_process_file_writes_tags_and_date(tmp_mp3):
-    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value={"release-list": []}),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_file(tmp_mp3, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=[], dry_run=False)
     tags = ID3(tmp_mp3)
     assert str(tags["TPE1"]) == "Seal"
@@ -255,8 +272,10 @@ def test_process_file_uses_mb_tracks_for_title(tmp_path):
     tags.delall("TIT2")
     tags.delall("TRCK")
     tags.save(track1_path)
-    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value={"release-list": []}),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_file(track1_path, dir_artist="Seal", dir_album="Seal", dir_year=1991, mb_tracks=mb_tracks, dry_run=False)
     result_tags = ID3(track1_path)
     assert str(result_tags["TIT2"]) == "Crazy"
@@ -266,15 +285,18 @@ def test_process_file_uses_mb_tracks_for_title(tmp_path):
 # process_directory — integration
 # ---------------------------------------------------------------------------
 
+
 def test_process_directory(tmp_path):
     """process_directory must process all MP3s in a folder without raising."""
     dest = str(tmp_path / "Seal - Seal (1991)")
     os.makedirs(dest)
     shutil.copy(FIXTURE_MP3, os.path.join(dest, "01 - Crazy.mp3"))
     shutil.copy(FIXTURE_MP3, os.path.join(dest, "02 - Future Love Paradise.mp3"))
-    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
-         patch("musicbrainzngs.get_release_by_id", return_value={"release": {"medium-list": []}}), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value={"release-list": []}),
+        patch("musicbrainzngs.get_release_by_id", return_value={"release": {"medium-list": []}}),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_directory(dest, dry_run=False)
     for fname in ("01 - Crazy.mp3", "02 - Future Love Paradise.mp3"):
         tags = ID3(os.path.join(dest, fname))
@@ -287,6 +309,7 @@ def test_process_directory(tmp_path):
 # ---------------------------------------------------------------------------
 # Guard clauses (empty inputs)
 # ---------------------------------------------------------------------------
+
 
 def test_mb_lookup_release_no_artist():
     year, tracks = fix._mb_lookup_release("", "Album")
@@ -312,12 +335,12 @@ def test_mb_lookup_track_no_title():
 # ValueError branches in MusicBrainz date parsing
 # ---------------------------------------------------------------------------
 
+
 def test_mb_lookup_release_invalid_date():
     """Non-numeric date string in release should be handled gracefully."""
     mock_result = {"release-list": [{"id": "abc", "date": "unknown"}]}
     mock_full = {"release": {"medium-list": []}}
-    with patch("musicbrainzngs.search_releases", return_value=mock_result), \
-         patch("musicbrainzngs.get_release_by_id", return_value=mock_full):
+    with patch("musicbrainzngs.search_releases", return_value=mock_result), patch("musicbrainzngs.get_release_by_id", return_value=mock_full):
         year, tracks = fix._mb_lookup_release("Artist", "Album")
     assert year is None
     assert tracks == []
@@ -335,11 +358,13 @@ def test_mb_lookup_track_invalid_date():
 # Exception handler in _write_tags (ID3NoHeaderError and general exception)
 # ---------------------------------------------------------------------------
 
+
 def test_write_tags_no_existing_id3_header(tmp_path):
     """Writing tags to a file that has no ID3 header should not raise."""
     bare = str(tmp_path / "bare.mp3")
     shutil.copy(FIXTURE_MP3, bare)
     from mutagen.id3 import ID3NoHeaderError
+
     with patch("mediatools.fix_mp3_meta.ID3", side_effect=[ID3NoHeaderError, ID3()]):
         fix._write_tags(bare, artist="A", title="T", album="Al", track=1, year=2000)
 
@@ -354,6 +379,7 @@ def test_write_tags_exception_is_swallowed(tmp_path):
 # Exception handler in _set_file_date
 # ---------------------------------------------------------------------------
 
+
 def test_set_file_date_exception_is_swallowed(tmp_mp3):
     with patch("os.utime", side_effect=OSError("permission denied")):
         fix._set_file_date(tmp_mp3, 2000)  # must not raise
@@ -363,23 +389,28 @@ def test_set_file_date_exception_is_swallowed(tmp_mp3):
 # ValueError branches in _process_file tag reading
 # ---------------------------------------------------------------------------
 
+
 def test_process_file_non_numeric_track_tag(tmp_path):
     """A non-numeric TRCK tag must not crash _process_file."""
     from mutagen.id3 import TRCK, TDRC
+
     dest = str(tmp_path / "track.mp3")
     shutil.copy(FIXTURE_MP3, dest)
     tags = ID3(dest)
     tags["TRCK"] = TRCK(encoding=3, text="not-a-number")
     tags["TDRC"] = TDRC(encoding=3, text="not-a-year")
     tags.save(dest)
-    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value={"release-list": []}),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_file(dest, dir_artist="Artist", dir_album="Album", dir_year=2001, mb_tracks=[], dry_run=False)
 
 
 # ---------------------------------------------------------------------------
 # MusicBrainz year lookup triggered from _process_file when year is unknown
 # ---------------------------------------------------------------------------
+
 
 def test_process_file_mb_year_lookup_from_album(tmp_path):
     """When dir_year is None and existing year tag is absent, year is fetched via MB album lookup."""
@@ -390,9 +421,11 @@ def test_process_file_mb_year_lookup_from_album(tmp_path):
     tags.save(dest)
     mock_release = {"release-list": [{"id": "x", "date": "1991"}]}
     mock_full = {"release": {"medium-list": []}}
-    with patch("musicbrainzngs.search_releases", return_value=mock_release), \
-         patch("musicbrainzngs.get_release_by_id", return_value=mock_full), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value=mock_release),
+        patch("musicbrainzngs.get_release_by_id", return_value=mock_full),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_file(dest, dir_artist="Seal", dir_album="Seal", dir_year=None, mb_tracks=[], dry_run=False)
     dt = datetime.datetime.fromtimestamp(os.path.getmtime(dest))
     assert dt.year == 1991
@@ -405,8 +438,10 @@ def test_process_file_mb_year_lookup_from_track(tmp_path):
     tags = ID3(dest)
     tags.delall("TDRC")
     tags.save(dest)
-    with patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": [{"release-list": [{"date": "1991"}]}]}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value={"release-list": []}),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": [{"release-list": [{"date": "1991"}]}]}),
+    ):
         fix._process_file(dest, dir_artist="Seal", dir_album="Seal", dir_year=None, mb_tracks=[], dry_run=False)
     dt = datetime.datetime.fromtimestamp(os.path.getmtime(dest))
     assert dt.year == 1991
@@ -415,6 +450,7 @@ def test_process_file_mb_year_lookup_from_track(tmp_path):
 # ---------------------------------------------------------------------------
 # MusicBrainz album lookup triggered from _process_directory when year unknown
 # ---------------------------------------------------------------------------
+
 
 def test_process_directory_mb_album_lookup(tmp_path):
     """_process_directory fires MB lookup when directory name has no year."""
@@ -426,9 +462,11 @@ def test_process_directory_mb_album_lookup(tmp_path):
     tags.save(os.path.join(dest, "01 - Crazy.mp3"))
     mock_release = {"release-list": [{"id": "x", "date": "1991"}]}
     mock_full = {"release": {"medium-list": []}}
-    with patch("musicbrainzngs.search_releases", return_value=mock_release), \
-         patch("musicbrainzngs.get_release_by_id", return_value=mock_full), \
-         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+    with (
+        patch("musicbrainzngs.search_releases", return_value=mock_release),
+        patch("musicbrainzngs.get_release_by_id", return_value=mock_full),
+        patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}),
+    ):
         fix._process_directory(dest, dry_run=False)
     dt = datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(dest, "01 - Crazy.mp3")))
     assert dt.year == 1991
@@ -438,17 +476,18 @@ def test_process_directory_mb_album_lookup(tmp_path):
 # main() entry point
 # ---------------------------------------------------------------------------
 
+
 def test_main_nonexistent_directory():
-    """main() exits with code 1 when the directory does not exist."""
-    with patch("sys.argv", ["fix-mp3-meta", "-d", "/nonexistent_path_xyz"]):
+    """main() logs a warning and exits 0 when a non-existent path is given."""
+    with patch("sys.argv", ["fix-mp3-meta", "-f", "/nonexistent_path_xyz"]):
         with pytest.raises(SystemExit) as exc:
             fix.main()
-    assert exc.value.code == 1
+    assert exc.value.code == 0
 
 
 def test_main_empty_directory(tmp_path):
     """main() exits with code 0 for an existing empty directory."""
-    with patch("sys.argv", ["fix-mp3-meta", "-d", str(tmp_path)]), \
+    with patch("sys.argv", ["fix-mp3-meta", "-f", str(tmp_path)]), \
          patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
          patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
         with pytest.raises(SystemExit) as exc:
@@ -459,7 +498,37 @@ def test_main_empty_directory(tmp_path):
 def test_main_dry_run(tmp_path):
     """main() --dry-run exits 0 and does not write any files."""
     shutil.copy(FIXTURE_MP3, str(tmp_path / "song.mp3"))
-    with patch("sys.argv", ["fix-mp3-meta", "-d", str(tmp_path), "--dry-run"]), \
+    with patch("sys.argv", ["fix-mp3-meta", "-f", str(tmp_path), "--dry-run"]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+
+
+def test_main_individual_files(tmp_path):
+    """main() accepts individual audio files (not directories) via -f."""
+    src = str(tmp_path / "01 - Crazy.mp3")
+    shutil.copy(FIXTURE_MP3, src)
+    tags = ID3(src)
+    tags.delall("TDRC")
+    tags.save(src)
+    with patch("sys.argv", ["fix-mp3-meta", "-f", src]), \
+         patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
+         patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
+        with pytest.raises(SystemExit) as exc:
+            fix.main()
+    assert exc.value.code == 0
+
+
+def test_main_mixed_files_and_dirs(tmp_path):
+    """main() handles a mix of a directory and an individual file."""
+    subdir = tmp_path / "Seal - Seal (1991)"
+    subdir.mkdir()
+    shutil.copy(FIXTURE_MP3, str(subdir / "01 - Crazy.mp3"))
+    lone_file = str(tmp_path / "song.mp3")
+    shutil.copy(FIXTURE_MP3, lone_file)
+    with patch("sys.argv", ["fix-mp3-meta", "-f", str(subdir), lone_file]), \
          patch("musicbrainzngs.search_releases", return_value={"release-list": []}), \
          patch("musicbrainzngs.search_recordings", return_value={"recording-list": []}):
         with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary

- Replace `-d/--directory` with `-f/--files` (`nargs="+"`) so users can drag-and-drop any mix of audio files and album directories, matching the `renamer` convention
  - Directories: processed as before (subdirs first, then root-level files)
  - Individual files: grouped by parent directory so artist/album context is inferred from the folder name (`Artist - Album` pattern)
  - Default when `-f` is omitted: `E:\Musique` (unchanged behaviour)
- Add M4A/AAC metadata support via `mutagen.mp4.MP4` (iTunes atoms: `©ART`, `©nam`, `©alb`, `trkn`, `©day`) — previously only MP3 ID3 tags were written
- Extract tag I/O into `_read_existing_tags()` to handle both formats cleanly
- Update `batch-files/fix-mp3-meta.bat` to pass `-f %*` so dropped files/folders are forwarded correctly
- Extend tests to cover new individual-file and mixed-input paths through `main()`

## Test plan

- [ ] Run `fix-mp3-meta --help` and confirm `-f/--files` is shown (no `-d`)
- [ ] Drag an album folder onto `fix-mp3-meta.bat` and verify tags are written
- [ ] Drag individual MP3 files onto `fix-mp3-meta.bat` and verify tags use the parent folder for context
- [ ] Run on a `.m4a` file and confirm iTunes tags are written (check with VLC or Windows Explorer properties)
- [ ] Run with no arguments and confirm `E:\Musique` is used as default
- [ ] `pytest tests/test_fix_mp3_meta.py` — all 55 tests pass, coverage ≥ 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)