### PR TITLE
Fix ruff2sonar.py: sync with sonar-tools reference implementation

### DIFF
--- a/ruff2sonar.py
+++ b/ruff2sonar.py
@@ -18,71 +18,96 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-"""Converts ruff --output-format=concise output to SonarQube generic external issues JSON format.
+"""Converts Ruff report format to Sonar external issues format"""
 
-See https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/importing-external-issues/generic-issue-data
-"""
-
-import sys
 import json
 import re
+import sys
+from typing import Optional
 
 TOOLNAME = "ruff"
 
-# Ruff concise line pattern: path:line:col: RULE_ID message  (optionally " [*]" fixable marker)
-_ISSUE_RE = re.compile(r"^([^:]+):(\d+):(\d+): ([A-Z0-9]+)(?: \[\*\])? (.+)$")
+TRIVY_TO_MQR_MAPPING = {"CRITICAL": "BLOCKER"}
+MAPPING = {"LOW": "MINOR", "MEDIUM": "MAJOR", "HIGH": "CRITICAL", "BLOCKER": "BLOCKER"}
+
+
+def _apply_range_marker(issue_range: dict, rule_id: str, end_line: Optional[int], start_col: Optional[int], end_col: Optional[int]) -> None:
+    """Update issue_range when a caret/underscore range marker line is parsed."""
+    issue_range["endLine"] = end_line or issue_range["startLine"]
+    if rule_id != "I001":
+        if start_col is not None:
+            issue_range["startColumn"] = start_col
+        if end_col is not None:
+            issue_range["endColumn"] = end_col
+    else:
+        issue_range["endLine"] -= 1
+        issue_range.pop("startColumn", None)
+        issue_range.pop("endColumn", None)
 
 
 def main() -> None:
-    """Read ruff concise output from stdin and write SonarQube external issues JSON to stdout."""
-    rules_dict: dict = {}
-    issue_list: list = []
-    current_issue: dict | None = None
+    """Main script entry point"""
+    v1 = len(sys.argv) > 1 and sys.argv[1] == "v1"
+    rules_dict = {}
+    issue_list = []
+    lines = sys.stdin.read().splitlines()
+    i = 0
+    sonar_issue = None
+    issue_range = {}
+    rule_id = ""
+    nblines = len(lines)
+    end_line = None
+    while i < nblines:
+        line = lines[i]
+        # Search for pattern like "sonar/projects.py:196:13: B904 Within an `except` clause, raise exceptions"
+        if m := re.match(r"^([^:]+):(\d+):(\d+): ([A-Z0-9]+)( \[\*\])? (.+)$", line):
+            if sonar_issue is not None:
+                issue_list.append(sonar_issue)
+                end_line = None
+            file_path = m.group(1)
+            rule_id = m.group(4)
+            message = m.group(6)
+            issue_range = {"startLine": int(m.group(2)), "endLine": int(m.group(2)), "startColumn": int(m.group(3)) - 1, "endColumn": int(m.group(3))}
+            sonar_issue = {
+                "engineId": TOOLNAME,
+                "ruleId": rule_id,
+                "effortMinutes": 5,
+                "primaryLocation": {"message": message, "filePath": file_path, "textRange": issue_range},
+            }
+            if v1:
+                sonar_issue["severity"] = "MAJOR"
+                sonar_issue["type"] = "CODE_SMELL"
+            rules_dict[rule_id] = {
+                "id": rule_id,
+                "name": rule_id,
+                "description": message,
+                "engineId": TOOLNAME,
+                "type": "CODE_SMELL",
+                "severity": "MAJOR",
+                "cleanCodeAttribute": "LOGICAL",
+                "impacts": [{"softwareQuality": "MAINTAINABILITY", "severity": "MEDIUM"}],
+            }
+        elif m := re.match(r"\s+\|\s\|(_+)\^ [A-Z0-9]+", line):
+            # Multi-line span closing marker: "   | |_____^ RUF012"
+            _apply_range_marker(issue_range, rule_id, end_line, None, len(m.group(1)))
+            end_line = None
+        elif m := re.match(r"\s+\| (\s+)(\^+) [A-Z0-9]+", line):
+            # Inline caret marker: "    |     ^^^^ RET505"
+            _apply_range_marker(issue_range, rule_id, end_line, len(m.group(1)), len(m.group(1)) + len(m.group(2)))
+            end_line = None
+        elif m := re.match(r"\s*(\d+)\s\|\s\|.*$", line):
+            end_line = int(m.group(1))
+        i += 1
 
-    for line in sys.stdin.read().splitlines():
-        m = _ISSUE_RE.match(line)
-        if not m:
-            continue
-        # Flush the previous issue before starting a new one
-        if current_issue is not None:
-            issue_list.append(current_issue)
+    if sonar_issue is not None:
+        issue_list.append(sonar_issue)
 
-        file_path = m.group(1).replace("\\", "/")
-        start_line = int(m.group(2))
-        start_col = int(m.group(3)) - 1  # ruff is 1-based, Sonar expects 0-based
-        rule_id = m.group(4)
-        message = m.group(5)
-
-        current_issue = {
-            "ruleId": rule_id,
-            "effortMinutes": 5,
-            "primaryLocation": {
-                "message": message,
-                "filePath": file_path,
-                "textRange": {
-                    "startLine": start_line,
-                    "endLine": start_line,
-                    "startColumn": start_col,
-                    "endColumn": start_col + 1,
-                },
-            },
-        }
-
-        # Keep one rule definition per rule_id (deduplicated by overwrite)
-        rules_dict[rule_id] = {
-            "id": rule_id,
-            "name": rule_id,
-            "description": message,
-            "engineId": TOOLNAME,
-            "cleanCodeAttribute": "LOGICAL",
-            "impacts": [{"softwareQuality": "MAINTAINABILITY", "severity": "MEDIUM"}],
-        }
-
-    # Flush the last issue
-    if current_issue is not None:
-        issue_list.append(current_issue)
-
-    print(json.dumps({"rules": list(rules_dict.values()), "issues": issue_list}, indent=2))
+    if len(issue_list) == 0:
+        return
+    external_issues = {"rules": list(rules_dict.values()), "issues": issue_list}
+    if v1:
+        external_issues.pop("rules")
+    print(json.dumps(external_issues, indent=3, separators=(",", ": ")))  # noqa: T201
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `_apply_range_marker()` helper for caret/underscore multi-line span markers
- Support `v1` output mode (legacy `severity`/`type` fields for older SonarQube versions)
- Include `engineId` in each issue object and `type`/`severity` in rules dict entries
- Handle multi-line span closing markers (`| |_____^ RULE` pattern)
- Use index-based `while` loop to track `end_line` across adjacent lines
- Early return when no issues found; use `indent=3` with custom separators

## Test plan
- [ ] Run `ruff --output-format=text | python ruff2sonar.py` and verify JSON output structure
- [ ] Verify `engineId` appears in each issue
- [ ] Verify `v1` argument produces legacy format without `rules` key

🤖 Generated with [Claude Code](https://claude.ai/claude-code)