### PR TITLE
Add audio-normalize tool (closes #380)

### DIFF
--- a/batch-files-audio/audio normalize.bat
+++ b/batch-files-audio/audio normalize.bat
@@ -1,0 +1,23 @@
+::
+:: media-tools
+:: Copyright (C) 2019-2024 Olivier Korach
+:: mailto:olivier.korach AT gmail DOT com
+::
+:: This program is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 3 of the License, or (at your option) any later version.
+::
+:: This program is distributed in the hope that it will be useful,
+:: but WITHOUT ANY WARRANTY; without even the implied warranty of
+:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+:: Lesser General Public License for more details.
+::
+:: You should have received a copy of the GNU Lesser General Public License
+:: along with this program; if not, write to the Free Software Foundation,
+:: Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+::
+
+audio-normalize -f %*
+
+pause

--- a/mediatools/audio_normalize.py
+++ b/mediatools/audio_normalize.py
@@ -1,0 +1,851 @@
+#!python3
+#
+# media-tools
+# Copyright (C) 2019-2024 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""
+audio-normalize: Comprehensive audio metadata normalizer.
+
+For each audio file:
+  - Determines artist, title, album, track from tags or filename/directory name
+  - Normalises capitalisation (artist → Title Case, title → Sentence case)
+  - Looks up MusicBrainz for release date (exact YYYY-MM-DD when available), genre, cover art
+  - Embeds cover art in the file; saves folder.jpg (max 600×600) for album folders
+  - Encodes genre using ID3v1 genres (0–79) + Winamp extensions (80–147)
+  - Writes tags for MP3 (ID3v1.1 + ID3v2.3), M4A, OGG, OPUS, FLAC
+  - Sets file timestamps to the exact (or approximate) release date
+  - Cleans up the filename: strips encoding postfixes and exotic Unicode characters
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import io
+import os
+import re
+import sys
+import time
+import unicodedata
+import argparse
+
+import musicbrainzngs
+import mutagen
+from mutagen.id3 import ID3, TIT2, TPE1, TALB, TRCK, TDRC, APIC, TCON, ID3NoHeaderError
+from mutagen.mp3 import MP3
+from mutagen.mp4 import MP4, MP4Cover
+from mutagen.flac import FLAC, Picture as FlacPicture
+
+try:
+    from PIL import Image as PilImage
+    _PIL_AVAILABLE = True
+except ImportError:
+    _PIL_AVAILABLE = False
+
+from mediatools import log
+import mediatools.utilities as util
+import utilities.file as fil
+
+# ---------------------------------------------------------------------------
+# MusicBrainz setup
+# ---------------------------------------------------------------------------
+musicbrainzngs.set_useragent("audio-video-tools", "0.7", "olivier.korach@gmail.com")
+
+# ---------------------------------------------------------------------------
+# ID3v1 genres 0–79 (standard) + Winamp extensions 80–147
+# ---------------------------------------------------------------------------
+_ID3V1_GENRES: list[str] = [
+    # 0–9
+    "Blues", "Classic Rock", "Country", "Dance", "Disco",
+    "Funk", "Grunge", "Hip-Hop", "Jazz", "Metal",
+    # 10–19
+    "New Age", "Oldies", "Other", "Pop", "Rhythm and Blues",
+    "Rap", "Reggae", "Rock", "Techno", "Industrial",
+    # 20–29
+    "Alternative", "Ska", "Death Metal", "Pranks", "Soundtrack",
+    "Euro-Techno", "Ambient", "Trip-Hop", "Vocal", "Jazz & Funk",
+    # 30–39
+    "Fusion", "Trance", "Classical", "Instrumental", "Acid",
+    "House", "Game", "Sound Clip", "Gospel", "Noise",
+    # 40–49
+    "Alternative Rock", "Bass", "Soul", "Punk", "Space",
+    "Meditative", "Instrumental Pop", "Instrumental Rock", "Ethnic", "Gothic",
+    # 50–59
+    "Darkwave", "Techno-Industrial", "Electronic", "Pop-Folk", "Eurodance",
+    "Dream", "Southern Rock", "Comedy", "Cult", "Gangsta",
+    # 60–69
+    "Top 40", "Christian Rap", "Pop/Funk", "Jungle", "Native US",
+    "Cabaret", "New Wave", "Psychedelic", "Rave", "Showtunes",
+    # 70–79
+    "Trailer", "Lo-Fi", "Tribal", "Acid Punk", "Acid Jazz",
+    "Polka", "Retro", "Musical", "Rock & Roll", "Hard Rock",
+    # 80–89 (Winamp)
+    "Folk", "Folk-Rock", "National Folk", "Swing", "Fast Fusion",
+    "Bebop", "Latin", "Revival", "Celtic", "Bluegrass",
+    # 90–99
+    "Avantgarde", "Gothic Rock", "Progressive Rock", "Psychedelic Rock", "Symphonic Rock",
+    "Slow Rock", "Big Band", "Chorus", "Easy Listening", "Acoustic",
+    # 100–109
+    "Humour", "Speech", "Chanson", "Opera", "Chamber Music",
+    "Sonata", "Symphony", "Booty Bass", "Primus", "Porn Groove",
+    # 110–119
+    "Satire", "Slow Jam", "Club", "Tango", "Samba",
+    "Folklore", "Ballad", "Power Ballad", "Rhythmic Soul", "Freestyle",
+    # 120–129
+    "Duet", "Punk Rock", "Drum Solo", "A Cappella", "Euro-House",
+    "Dance Hall", "Goa", "Drum & Bass", "Club-House", "Hardcore Techno",
+    # 130–139
+    "Terror", "Indie", "BritPop", "Negerpunk", "Polsk Punk",
+    "Beat", "Christian Gangsta Rap", "Heavy Metal", "Black Metal", "Crossover",
+    # 140–147
+    "Contemporary Christian", "Christian Rock", "Merengue", "Salsa",
+    "Thrash Metal", "Anime", "JPop", "Synthpop",
+]
+_GENRE_LOWER: dict[str, int] = {g.lower(): i for i, g in enumerate(_ID3V1_GENRES)}
+
+# Encoding postfix pattern (e.g. "(128kbit_AAC)", "[320kbps MP3]")
+_ENCODING_POSTFIX_RE = re.compile(r"\s*[\(\[][^()\[\]]*\d+\s*k(?:bit|bps|b)?[^()\[\]]*[\)\]]\s*$", re.IGNORECASE)
+
+# Directory: "Artist - Album" or "Artist - Album (Year)" or "Artist"
+_DIR_ARTIST_ALBUM_RE = re.compile(r"^(.+?)\s+-\s+(.+?)(?:\s*[\(\[]\s*(\d{4})\s*[\)\]])?\s*$")
+# Track prefix: "01 ", "01 - ", "01. ", "(01) " etc.
+_TRACK_PREFIX_RE = re.compile(r"^\s*[\(\[]?(\d{1,3})[\)\].]?\s*[-.]?\s*")
+# Artist - Title separator
+_ARTIST_TITLE_RE = re.compile(r"^(.+?)\s+-\s+(.+)$")
+
+_COVER_FILENAME = "folder.jpg"
+_MAX_COVER_SIZE = 600
+
+
+# ---------------------------------------------------------------------------
+# Genre helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_genre(genre_name: str) -> str | None:
+    """Returns the canonical genre name if it matches an ID3v1 genre (0–147), else None."""
+    if not genre_name:
+        return None
+    idx = _GENRE_LOWER.get(genre_name.lower().strip())
+    if idx is not None:
+        return _ID3V1_GENRES[idx]
+    # Fuzzy: try if any known genre starts with the given name
+    for name, i in _GENRE_LOWER.items():
+        if name.startswith(genre_name.lower().strip()):
+            return _ID3V1_GENRES[i]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Filename cleanup
+# ---------------------------------------------------------------------------
+
+
+def _strip_encoding_postfix(base_name: str) -> str:
+    """Remove encoding postfixes like '(128kbit_AAC)' or '[320kbps MP3]'."""
+    return _ENCODING_POSTFIX_RE.sub("", base_name).rstrip()
+
+
+def _strip_exotic_unicode(text: str) -> str:
+    """Replace non-ASCII chars with ASCII equivalents (via NFKD decomposition) or remove them."""
+    # Decompose (é → e + combining accent) then drop combining marks
+    decomposed = unicodedata.normalize("NFKD", text)
+    ascii_only = "".join(c for c in decomposed if unicodedata.category(c) != "Mn" and ord(c) < 128)
+    # Collapse multiple spaces/underscores left by removed chars
+    return re.sub(r"[ _]{2,}", " ", ascii_only).strip()
+
+
+def _clean_basename(base_name: str) -> str:
+    """Return a cleaned file base name (no extension): strip postfixes and exotic unicode."""
+    return _strip_exotic_unicode(_strip_encoding_postfix(base_name))
+
+
+# ---------------------------------------------------------------------------
+# Capitalisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _title_case(text: str) -> str:
+    if not text:
+        return text
+    return " ".join(w.capitalize() for w in text.split())
+
+
+def _sentence_case(text: str) -> str:
+    if not text:
+        return text
+    return text[0].upper() + text[1:].lower()
+
+
+# ---------------------------------------------------------------------------
+# Filename / directory parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_dir_name(dir_name: str) -> tuple[str | None, str | None, int | None]:
+    """Returns (artist, album, year) from a directory base name."""
+    m = _DIR_ARTIST_ALBUM_RE.match(dir_name)
+    if m:
+        artist = _title_case(m.group(1).strip())
+        album = m.group(2).strip()
+        year = int(m.group(3)) if m.group(3) else None
+        return artist, album, year
+    return _title_case(dir_name.strip()), None, None
+
+
+def _parse_file_name(base_name: str) -> tuple[int | None, str | None, str | None]:
+    """Returns (track_number, artist, title) parsed from a file base name (no extension)."""
+    track: int | None = None
+    artist: str | None = None
+    title: str | None = None
+
+    tm = _TRACK_PREFIX_RE.match(base_name)
+    if tm:
+        track = int(tm.group(1))
+        rest = base_name[tm.end():].strip()
+    else:
+        rest = base_name.strip()
+
+    am = _ARTIST_TITLE_RE.match(rest)
+    if am:
+        artist = _title_case(am.group(1).strip())
+        title = _sentence_case(am.group(2).strip())
+    else:
+        title = _sentence_case(rest) or None
+
+    return track, artist, title
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz lookup
+# ---------------------------------------------------------------------------
+
+
+def _parse_mb_date(date_str: str) -> tuple[int | None, datetime.date | None]:
+    """Parse a MusicBrainz date string (YYYY, YYYY-MM, YYYY-MM-DD) into (year, date)."""
+    if not date_str:
+        return None, None
+    parts = date_str.split("-")
+    try:
+        year = int(parts[0])
+        month = int(parts[1]) if len(parts) > 1 else 1
+        day = int(parts[2]) if len(parts) > 2 else 1
+        return year, datetime.date(year, month, day)
+    except (ValueError, IndexError):
+        return None, None
+
+
+def _mb_lookup_release(artist: str, album: str) -> tuple[int | None, datetime.date | None, str | None, list[str], str | None]:
+    """Returns (year, exact_date, genre, track_titles, release_id) for the best MusicBrainz match."""
+    if not artist or not album:
+        return None, None, None, [], None
+    try:
+        result = musicbrainzngs.search_releases(artist=artist, release=album, limit=3)
+        releases = result.get("release-list", [])
+        if not releases:
+            return None, None, None, [], None
+        rel = releases[0]
+        release_id = rel["id"]
+        year, exact_date = _parse_mb_date(rel.get("date", ""))
+
+        # Fetch full release with recordings and genres
+        full = musicbrainzngs.get_release_by_id(release_id, includes=["recordings", "genres", "tags"])
+        release = full.get("release", {})
+
+        # Refresh date from full record
+        full_date_str = release.get("date", "")
+        if full_date_str:
+            year, exact_date = _parse_mb_date(full_date_str)
+
+        # Genre from release
+        genre: str | None = None
+        for g in release.get("genre-list", []):
+            candidate = _find_genre(g.get("name", ""))
+            if candidate:
+                genre = candidate
+                break
+        if not genre:
+            for t in release.get("tag-list", []):
+                candidate = _find_genre(t.get("name", ""))
+                if candidate:
+                    genre = candidate
+                    break
+
+        # Track titles
+        tracks: list[str] = []
+        for medium in release.get("medium-list", []):
+            for track in medium.get("track-list", []):
+                tracks.append(track.get("recording", {}).get("title", ""))
+
+        return year, exact_date, genre, tracks, release_id
+    except Exception as e:
+        log.logger.warning("MusicBrainz lookup failed for '%s' / '%s': %s", artist, album, str(e))
+        return None, None, None, [], None
+
+
+def _mb_lookup_track(artist: str, title: str) -> tuple[int | None, datetime.date | None]:
+    """Returns (year, exact_date) for a specific recording from MusicBrainz."""
+    if not artist or not title:
+        return None, None
+    try:
+        result = musicbrainzngs.search_recordings(artist=artist, recording=title, limit=3)
+        for rec in result.get("recording-list", []):
+            for release in rec.get("release-list", []):
+                year, exact_date = _parse_mb_date(release.get("date", ""))
+                if year:
+                    return year, exact_date
+    except Exception as e:
+        log.logger.warning("MusicBrainz recording lookup failed for '%s' / '%s': %s", artist, title, str(e))
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Cover art
+# ---------------------------------------------------------------------------
+
+
+def _fetch_cover_art(release_id: str) -> bytes | None:
+    """Fetch the front cover image bytes from MusicBrainz Cover Art Archive."""
+    if not release_id:
+        return None
+    try:
+        data = musicbrainzngs.get_image_front(release_id, size="500")
+        if isinstance(data, bytes) and len(data) > 0:
+            return data
+    except Exception as e:
+        log.logger.debug("Cover art not available for %s: %s", release_id, str(e))
+    return None
+
+
+def _resize_image(image_bytes: bytes, max_size: int = _MAX_COVER_SIZE) -> bytes:
+    """Resize image so neither dimension exceeds max_size. Requires Pillow."""
+    if not _PIL_AVAILABLE:
+        return image_bytes
+    try:
+        img = PilImage.open(io.BytesIO(image_bytes))
+        if img.width > max_size or img.height > max_size:
+            img.thumbnail((max_size, max_size), PilImage.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=90)
+        return buf.getvalue()
+    except Exception as e:
+        log.logger.warning("Image resize failed: %s", str(e))
+        return image_bytes
+
+
+def _save_cover_to_folder(dirpath: str, image_bytes: bytes) -> None:
+    """Save cover art as folder.jpg (max 600×600) in the given directory."""
+    cover_path = os.path.join(dirpath, _COVER_FILENAME)
+    try:
+        resized = _resize_image(image_bytes)
+        with open(cover_path, "wb") as f:
+            f.write(resized)
+        log.logger.info("Saved cover art to %s", cover_path)
+    except Exception as e:
+        log.logger.error("Failed to save cover art to %s: %s", cover_path, str(e))
+
+
+def _make_flac_picture(image_bytes: bytes) -> FlacPicture:
+    pic = FlacPicture()
+    pic.type = 3  # Front cover
+    pic.mime = "image/jpeg"
+    pic.data = image_bytes
+    return pic
+
+
+# ---------------------------------------------------------------------------
+# Audio format detection
+# ---------------------------------------------------------------------------
+
+_VORBIS_COMMENT_FORMATS = ("ogg", "opus", "flac", "oga")
+
+
+def _audio_format(filepath: str) -> str:
+    return fil.extension(filepath).lower()
+
+
+def _is_m4a(filepath: str) -> bool:
+    return _audio_format(filepath) in ("m4a", "aac")
+
+
+def _is_mp3(filepath: str) -> bool:
+    return _audio_format(filepath) == "mp3"
+
+
+def _is_vorbis(filepath: str) -> bool:
+    return _audio_format(filepath) in _VORBIS_COMMENT_FORMATS
+
+
+# ---------------------------------------------------------------------------
+# Tag reading
+# ---------------------------------------------------------------------------
+
+_M4A_TAG_MAP = {"artist": "©ART", "title": "©nam", "album": "©alb", "year": "©day", "track": "trkn", "genre": "©gen"}
+
+
+def _read_existing_tags(filepath: str) -> tuple[str | None, str | None, str | None, int | None, int | None, str | None]:
+    """Returns (artist, title, album, track, year, genre) from existing file tags."""
+    artist = title = album = genre = None
+    track = year = None
+    try:
+        if _is_m4a(filepath):
+            tags = MP4(filepath).tags or {}
+            artist = (tags.get(_M4A_TAG_MAP["artist"], [None])[0] or "").strip() or None
+            title = (tags.get(_M4A_TAG_MAP["title"], [None])[0] or "").strip() or None
+            album = (tags.get(_M4A_TAG_MAP["album"], [None])[0] or "").strip() or None
+            genre = (tags.get(_M4A_TAG_MAP["genre"], [None])[0] or "").strip() or None
+            trkn = tags.get(_M4A_TAG_MAP["track"])
+            if trkn:
+                try:
+                    track = int(trkn[0][0])
+                except (ValueError, IndexError, TypeError):
+                    pass
+            day = (tags.get(_M4A_TAG_MAP["year"], [None])[0] or "").strip()
+            if day:
+                try:
+                    year = int(day[:4])
+                except ValueError:
+                    pass
+        elif _is_vorbis(filepath):
+            audio = mutagen.File(filepath)
+            if audio and audio.tags:
+                artist = (audio.tags.get("artist", [None])[0] or "").strip() or None
+                title = (audio.tags.get("title", [None])[0] or "").strip() or None
+                album = (audio.tags.get("album", [None])[0] or "").strip() or None
+                genre = (audio.tags.get("genre", [None])[0] or "").strip() or None
+                trk_raw = (audio.tags.get("tracknumber", [None])[0] or "").strip()
+                if trk_raw:
+                    try:
+                        track = int(trk_raw.split("/")[0])
+                    except ValueError:
+                        pass
+                yr_raw = (audio.tags.get("date", [None])[0] or "").strip()
+                if yr_raw:
+                    try:
+                        year = int(yr_raw[:4])
+                    except ValueError:
+                        pass
+        else:
+            audio = MP3(filepath)
+            if audio.tags:
+                artist = str(audio.tags.get("TPE1", "")).strip() or None
+                title = str(audio.tags.get("TIT2", "")).strip() or None
+                album = str(audio.tags.get("TALB", "")).strip() or None
+                genre_tag = audio.tags.get("TCON")
+                genre = str(genre_tag).strip() or None if genre_tag else None
+                trk_raw = str(audio.tags.get("TRCK", "")).strip()
+                if trk_raw:
+                    try:
+                        track = int(trk_raw.split("/")[0])
+                    except ValueError:
+                        pass
+                yr_raw = str(audio.tags.get("TDRC", "")).strip()
+                if yr_raw:
+                    try:
+                        year = int(yr_raw[:4])
+                    except ValueError:
+                        pass
+    except Exception as e:
+        log.logger.warning("Could not read tags from %s: %s", filepath, str(e))
+    return artist, title, album, track, year, genre
+
+
+# ---------------------------------------------------------------------------
+# Tag writing
+# ---------------------------------------------------------------------------
+
+
+def _write_tags(
+    filepath: str,
+    artist: str | None,
+    title: str | None,
+    album: str | None,
+    track: int | None,
+    year: int | None,
+    genre: str | None,
+    cover_bytes: bytes | None,
+) -> None:
+    """Write tags to an audio file across all supported formats."""
+    try:
+        if _is_m4a(filepath):
+            _write_tags_m4a(filepath, artist, title, album, track, year, genre, cover_bytes)
+        elif _is_vorbis(filepath):
+            _write_tags_vorbis(filepath, artist, title, album, track, year, genre, cover_bytes)
+        else:
+            _write_tags_mp3(filepath, artist, title, album, track, year, genre, cover_bytes)
+        log.logger.info("Tags written: %s | artist=%s title=%s album=%s track=%s year=%s genre=%s", filepath, artist, title, album, track, year, genre)
+    except Exception as e:
+        log.logger.error("Failed to write tags for %s: %s", filepath, str(e))
+
+
+def _write_tags_mp3(
+    filepath: str,
+    artist: str | None,
+    title: str | None,
+    album: str | None,
+    track: int | None,
+    year: int | None,
+    genre: str | None,
+    cover_bytes: bytes | None,
+) -> None:
+    try:
+        tags = ID3(filepath)
+    except ID3NoHeaderError:
+        tags = ID3()
+    if artist:
+        tags["TPE1"] = TPE1(encoding=3, text=artist)
+    if title:
+        tags["TIT2"] = TIT2(encoding=3, text=title)
+    if album:
+        tags["TALB"] = TALB(encoding=3, text=album)
+    if track is not None:
+        tags["TRCK"] = TRCK(encoding=3, text=str(track))
+    if year is not None:
+        tags["TDRC"] = TDRC(encoding=3, text=str(year))
+    if genre:
+        tags["TCON"] = TCON(encoding=3, text=genre)
+    if cover_bytes:
+        tags["APIC"] = APIC(encoding=3, mime="image/jpeg", type=3, desc="Cover", data=cover_bytes)
+    tags.save(filepath, v1=2, v2_version=3)
+
+
+def _write_tags_m4a(
+    filepath: str,
+    artist: str | None,
+    title: str | None,
+    album: str | None,
+    track: int | None,
+    year: int | None,
+    genre: str | None,
+    cover_bytes: bytes | None,
+) -> None:
+    audio = MP4(filepath)
+    if audio.tags is None:
+        audio.add_tags()
+    if artist:
+        audio.tags[_M4A_TAG_MAP["artist"]] = [artist]
+    if title:
+        audio.tags[_M4A_TAG_MAP["title"]] = [title]
+    if album:
+        audio.tags[_M4A_TAG_MAP["album"]] = [album]
+    if track is not None:
+        audio.tags[_M4A_TAG_MAP["track"]] = [(track, 0)]
+    if year is not None:
+        audio.tags[_M4A_TAG_MAP["year"]] = [str(year)]
+    if genre:
+        audio.tags[_M4A_TAG_MAP["genre"]] = [genre]
+    if cover_bytes:
+        audio.tags["covr"] = [MP4Cover(cover_bytes, imageformat=MP4Cover.FORMAT_JPEG)]
+    audio.save()
+
+
+def _write_tags_vorbis(
+    filepath: str,
+    artist: str | None,
+    title: str | None,
+    album: str | None,
+    track: int | None,
+    year: int | None,
+    genre: str | None,
+    cover_bytes: bytes | None,
+) -> None:
+    audio = mutagen.File(filepath)
+    if audio is None:
+        log.logger.error("mutagen.File() returned None for %s", filepath)
+        return
+    if audio.tags is None:
+        audio.add_tags()
+    if artist:
+        audio.tags["ARTIST"] = [artist]
+    if title:
+        audio.tags["TITLE"] = [title]
+    if album:
+        audio.tags["ALBUM"] = [album]
+    if track is not None:
+        audio.tags["TRACKNUMBER"] = [str(track)]
+    if year is not None:
+        audio.tags["DATE"] = [str(year)]
+    if genre:
+        audio.tags["GENRE"] = [genre]
+    if cover_bytes:
+        # FLAC has a native Picture block; OGG/OPUS use METADATA_BLOCK_PICTURE
+        if isinstance(audio, FLAC):
+            audio.clear_pictures()
+            audio.add_picture(_make_flac_picture(cover_bytes))
+        else:
+            pic = _make_flac_picture(cover_bytes)
+            encoded = base64.b64encode(pic.write()).decode("ascii")
+            audio.tags["METADATA_BLOCK_PICTURE"] = [encoded]
+    audio.save()
+
+
+# ---------------------------------------------------------------------------
+# File timestamp
+# ---------------------------------------------------------------------------
+
+
+def _set_file_date(filepath: str, release_date: datetime.date) -> None:
+    """Sets file timestamps to the release date at 12:00:00."""
+    try:
+        dt = datetime.datetime(release_date.year, release_date.month, release_date.day, 12, 0, 0)
+        ts = dt.timestamp()
+        os.utime(filepath, (ts, ts))
+        log.logger.info("Set file date of %s to %s 12:00", filepath, release_date.isoformat())
+    except Exception as e:
+        log.logger.error("Failed to set file date for %s: %s", filepath, str(e))
+
+
+# ---------------------------------------------------------------------------
+# Filename rename
+# ---------------------------------------------------------------------------
+
+
+def _rename_file(filepath: str, new_base: str) -> str:
+    """Rename file to new_base (keeping extension). Returns new path."""
+    dirpath = os.path.dirname(filepath)
+    ext = os.path.splitext(filepath)[1]
+    new_path = os.path.join(dirpath, new_base + ext)
+    if os.path.abspath(filepath) == os.path.abspath(new_path):
+        return filepath
+    try:
+        os.rename(filepath, new_path)
+        log.logger.info("Renamed %s → %s", os.path.basename(filepath), new_base + ext)
+        return new_path
+    except OSError as e:
+        log.logger.error("Rename failed for %s: %s", filepath, str(e))
+        return filepath
+
+
+# ---------------------------------------------------------------------------
+# Per-file processing
+# ---------------------------------------------------------------------------
+
+
+def _process_file(
+    filepath: str,
+    dir_artist: str | None,
+    dir_album: str | None,
+    dir_year: int | None,
+    dir_date: datetime.date | None,
+    dir_genre: str | None,
+    mb_tracks: list[str],
+    cover_bytes: bytes | None,
+    dry_run: bool,
+) -> str:
+    """Processes a single audio file. Returns (possibly updated) filepath."""
+    base, ext = os.path.splitext(os.path.basename(filepath))
+
+    # 1. Clean filename
+    clean_base = _clean_basename(base)
+
+    # 2. Parse cleaned filename
+    fn_track, fn_artist, fn_title = _parse_file_name(clean_base)
+
+    # 3. Read existing tags
+    existing_artist, existing_title, existing_album, existing_track, existing_year, existing_genre = _read_existing_tags(filepath)
+
+    # 4. Resolve final values
+    artist = existing_artist or fn_artist or dir_artist
+    title = existing_title or fn_title
+    album = existing_album or dir_album
+    track = existing_track or fn_track
+    year = existing_year or dir_year
+    release_date = dir_date
+    genre = existing_genre or dir_genre
+
+    # 5. MusicBrainz track title from track list
+    if not title and track is not None and mb_tracks and (track - 1) < len(mb_tracks):
+        title = _sentence_case(mb_tracks[track - 1])
+
+    # 6. MusicBrainz year/date lookup if still missing
+    if year is None and artist and album:
+        mb_year, mb_date, mb_genre, _, _ = _mb_lookup_release(artist, album)
+        year = mb_year
+        release_date = mb_date
+        if not genre:
+            genre = mb_genre
+    if year is None and artist and title:
+        year, release_date = _mb_lookup_track(artist, title)
+
+    if year and not release_date:
+        release_date = datetime.date(year, 1, 1)
+
+    # 7. Normalise capitalisation
+    if artist:
+        artist = _title_case(artist)
+    if title:
+        title = _sentence_case(title)
+
+    # 8. Validate genre against ID3v1 list
+    if genre:
+        genre = _find_genre(genre) or genre
+
+    log.logger.info(
+        "File: %s  artist=%s  title=%s  album=%s  track=%s  year=%s  genre=%s  date=%s",
+        base, artist, title, album, track, year, genre, release_date,
+    )
+
+    if dry_run:
+        return filepath
+
+    # 9. Rename file if needed
+    if clean_base != base:
+        filepath = _rename_file(filepath, clean_base)
+
+    # 10. Write tags
+    _write_tags(filepath, artist, title, album, track, year, genre, cover_bytes)
+
+    # 11. Set file timestamp
+    if release_date:
+        _set_file_date(filepath, release_date)
+    elif year:
+        _set_file_date(filepath, datetime.date(year, 1, 1))
+
+    return filepath
+
+
+# ---------------------------------------------------------------------------
+# Per-directory processing
+# ---------------------------------------------------------------------------
+
+
+def _process_directory(dirpath: str, dry_run: bool) -> None:
+    """Processes all audio files in a single directory."""
+    dir_name = os.path.basename(dirpath)
+    dir_artist, dir_album, dir_year = _parse_dir_name(dir_name)
+    log.logger.info("Directory: %s  →  artist=%s  album=%s  year=%s", dir_name, dir_artist, dir_album, dir_year)
+
+    mb_tracks: list[str] = []
+    dir_date: datetime.date | None = None
+    dir_genre: str | None = None
+    cover_bytes: bytes | None = None
+    release_id: str | None = None
+
+    if dir_artist and dir_album:
+        mb_year, mb_date, mb_genre, mb_tracks, release_id = _mb_lookup_release(dir_artist, dir_album)
+        if mb_year and dir_year is None:
+            dir_year = mb_year
+        if mb_date:
+            dir_date = mb_date
+        if mb_genre:
+            dir_genre = mb_genre
+
+    if dir_year and not dir_date:
+        dir_date = datetime.date(dir_year, 1, 1)
+
+    # Fetch cover art from MusicBrainz
+    if release_id:
+        cover_bytes = _fetch_cover_art(release_id)
+
+    # Save folder cover (only if this looks like an album folder with actual cover art)
+    if cover_bytes and dir_album and not dry_run:
+        existing_cover = os.path.join(dirpath, _COVER_FILENAME)
+        if not os.path.exists(existing_cover):
+            _save_cover_to_folder(dirpath, cover_bytes)
+
+    audio_files = sorted(
+        [os.path.join(dirpath, f) for f in os.listdir(dirpath) if fil.is_audio_file(f)],
+        key=lambda p: os.path.basename(p).lower(),
+    )
+    log.logger.info("Found %d audio file(s) in %s", len(audio_files), dirpath)
+
+    for filepath in audio_files:
+        _process_file(filepath, dir_artist, dir_album, dir_year, dir_date, dir_genre, mb_tracks, cover_bytes, dry_run)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    util.init("audio-normalize")
+    parser = argparse.ArgumentParser(description="Normalize audio metadata, cover art, and filenames")
+    parser.add_argument("-f", "--files", nargs="+", help="Files and/or directories to process (default: E:\\Musique)")
+    parser.add_argument("--dry-run", action="store_true", help="Parse and log actions without modifying anything")
+    parser.add_argument("-g", "--debug", required=False, type=int, help="Debug level")
+    args = parser.parse_args()
+
+    if args.debug:
+        util.set_debug_level(args.debug)
+
+    inputs = args.files if args.files else [r"E:\Musique"]
+    dry_run = args.dry_run
+    if dry_run:
+        log.logger.info("DRY RUN mode — no files will be modified")
+
+    dirs_to_process: list[str] = []
+    files_by_dir: dict[str, list[str]] = {}
+
+    for entry in inputs:
+        entry = os.path.abspath(entry)
+        if os.path.isdir(entry):
+            dirs_to_process.append(entry)
+        elif fil.is_audio_file(entry):
+            parent = os.path.dirname(entry)
+            files_by_dir.setdefault(parent, []).append(entry)
+        else:
+            log.logger.warning("Skipping %s: not a directory or audio file", entry)
+
+    for root in sorted(dirs_to_process):
+        if not os.path.isdir(root):
+            log.logger.error("Directory not found: %s", root)
+            continue
+        subdirs = sorted([os.path.join(root, d) for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))])
+        root_audio = [os.path.join(root, f) for f in os.listdir(root) if fil.is_audio_file(f)]
+        if subdirs:
+            log.logger.info("Processing %d subdirectories under %s", len(subdirs), root)
+            for subdir in subdirs:
+                log.logger.info("=== Processing directory: %s ===", subdir)
+                try:
+                    _process_directory(subdir, dry_run)
+                except Exception as e:
+                    log.logger.error("Error processing %s: %s", subdir, str(e))
+        if root_audio:
+            log.logger.info("Processing %d audio file(s) directly in %s", len(root_audio), root)
+            _process_directory(root, dry_run)
+
+    for parent, file_list in sorted(files_by_dir.items()):
+        dir_artist, dir_album, dir_year = _parse_dir_name(os.path.basename(parent))
+        mb_tracks: list[str] = []
+        dir_date: datetime.date | None = None
+        dir_genre: str | None = None
+        cover_bytes: bytes | None = None
+        release_id: str | None = None
+        if dir_artist and dir_album:
+            mb_year, dir_date, dir_genre, mb_tracks, release_id = _mb_lookup_release(dir_artist, dir_album)
+            if mb_year and dir_year is None:
+                dir_year = mb_year
+        if dir_year and not dir_date:
+            dir_date = datetime.date(dir_year, 1, 1)
+        if release_id:
+            cover_bytes = _fetch_cover_art(release_id)
+        log.logger.info("Processing %d file(s) from %s", len(file_list), parent)
+        for filepath in sorted(file_list):
+            try:
+                _process_file(filepath, dir_artist, dir_album, dir_year, dir_date, dir_genre, mb_tracks, cover_bytes, dry_run)
+            except Exception as e:
+                log.logger.error("Error processing %s: %s", filepath, str(e))
+
+    log.logger.info("Done.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/mediatools/audio_normalize.py
+++ b/mediatools/audio_normalize.py
@@ -54,6 +54,7 @@ from mutagen.flac import FLAC, Picture as FlacPicture
 
 try:
     from PIL import Image as PilImage
+
     _PIL_AVAILABLE = True
 except ImportError:
     _PIL_AVAILABLE = False
@@ -72,50 +73,168 @@ musicbrainzngs.set_useragent("audio-video-tools", "0.7", "olivier.korach@gmail.c
 # ---------------------------------------------------------------------------
 _ID3V1_GENRES: list[str] = [
     # 0–9
-    "Blues", "Classic Rock", "Country", "Dance", "Disco",
-    "Funk", "Grunge", "Hip-Hop", "Jazz", "Metal",
+    "Blues",
+    "Classic Rock",
+    "Country",
+    "Dance",
+    "Disco",
+    "Funk",
+    "Grunge",
+    "Hip-Hop",
+    "Jazz",
+    "Metal",
     # 10–19
-    "New Age", "Oldies", "Other", "Pop", "Rhythm and Blues",
-    "Rap", "Reggae", "Rock", "Techno", "Industrial",
+    "New Age",
+    "Oldies",
+    "Other",
+    "Pop",
+    "Rhythm and Blues",
+    "Rap",
+    "Reggae",
+    "Rock",
+    "Techno",
+    "Industrial",
     # 20–29
-    "Alternative", "Ska", "Death Metal", "Pranks", "Soundtrack",
-    "Euro-Techno", "Ambient", "Trip-Hop", "Vocal", "Jazz & Funk",
+    "Alternative",
+    "Ska",
+    "Death Metal",
+    "Pranks",
+    "Soundtrack",
+    "Euro-Techno",
+    "Ambient",
+    "Trip-Hop",
+    "Vocal",
+    "Jazz & Funk",
     # 30–39
-    "Fusion", "Trance", "Classical", "Instrumental", "Acid",
-    "House", "Game", "Sound Clip", "Gospel", "Noise",
+    "Fusion",
+    "Trance",
+    "Classical",
+    "Instrumental",
+    "Acid",
+    "House",
+    "Game",
+    "Sound Clip",
+    "Gospel",
+    "Noise",
     # 40–49
-    "Alternative Rock", "Bass", "Soul", "Punk", "Space",
-    "Meditative", "Instrumental Pop", "Instrumental Rock", "Ethnic", "Gothic",
+    "Alternative Rock",
+    "Bass",
+    "Soul",
+    "Punk",
+    "Space",
+    "Meditative",
+    "Instrumental Pop",
+    "Instrumental Rock",
+    "Ethnic",
+    "Gothic",
     # 50–59
-    "Darkwave", "Techno-Industrial", "Electronic", "Pop-Folk", "Eurodance",
-    "Dream", "Southern Rock", "Comedy", "Cult", "Gangsta",
+    "Darkwave",
+    "Techno-Industrial",
+    "Electronic",
+    "Pop-Folk",
+    "Eurodance",
+    "Dream",
+    "Southern Rock",
+    "Comedy",
+    "Cult",
+    "Gangsta",
     # 60–69
-    "Top 40", "Christian Rap", "Pop/Funk", "Jungle", "Native US",
-    "Cabaret", "New Wave", "Psychedelic", "Rave", "Showtunes",
+    "Top 40",
+    "Christian Rap",
+    "Pop/Funk",
+    "Jungle",
+    "Native US",
+    "Cabaret",
+    "New Wave",
+    "Psychedelic",
+    "Rave",
+    "Showtunes",
     # 70–79
-    "Trailer", "Lo-Fi", "Tribal", "Acid Punk", "Acid Jazz",
-    "Polka", "Retro", "Musical", "Rock & Roll", "Hard Rock",
+    "Trailer",
+    "Lo-Fi",
+    "Tribal",
+    "Acid Punk",
+    "Acid Jazz",
+    "Polka",
+    "Retro",
+    "Musical",
+    "Rock & Roll",
+    "Hard Rock",
     # 80–89 (Winamp)
-    "Folk", "Folk-Rock", "National Folk", "Swing", "Fast Fusion",
-    "Bebop", "Latin", "Revival", "Celtic", "Bluegrass",
+    "Folk",
+    "Folk-Rock",
+    "National Folk",
+    "Swing",
+    "Fast Fusion",
+    "Bebop",
+    "Latin",
+    "Revival",
+    "Celtic",
+    "Bluegrass",
     # 90–99
-    "Avantgarde", "Gothic Rock", "Progressive Rock", "Psychedelic Rock", "Symphonic Rock",
-    "Slow Rock", "Big Band", "Chorus", "Easy Listening", "Acoustic",
+    "Avantgarde",
+    "Gothic Rock",
+    "Progressive Rock",
+    "Psychedelic Rock",
+    "Symphonic Rock",
+    "Slow Rock",
+    "Big Band",
+    "Chorus",
+    "Easy Listening",
+    "Acoustic",
     # 100–109
-    "Humour", "Speech", "Chanson", "Opera", "Chamber Music",
-    "Sonata", "Symphony", "Booty Bass", "Primus", "Porn Groove",
+    "Humour",
+    "Speech",
+    "Chanson",
+    "Opera",
+    "Chamber Music",
+    "Sonata",
+    "Symphony",
+    "Booty Bass",
+    "Primus",
+    "Porn Groove",
     # 110–119
-    "Satire", "Slow Jam", "Club", "Tango", "Samba",
-    "Folklore", "Ballad", "Power Ballad", "Rhythmic Soul", "Freestyle",
+    "Satire",
+    "Slow Jam",
+    "Club",
+    "Tango",
+    "Samba",
+    "Folklore",
+    "Ballad",
+    "Power Ballad",
+    "Rhythmic Soul",
+    "Freestyle",
     # 120–129
-    "Duet", "Punk Rock", "Drum Solo", "A Cappella", "Euro-House",
-    "Dance Hall", "Goa", "Drum & Bass", "Club-House", "Hardcore Techno",
+    "Duet",
+    "Punk Rock",
+    "Drum Solo",
+    "A Cappella",
+    "Euro-House",
+    "Dance Hall",
+    "Goa",
+    "Drum & Bass",
+    "Club-House",
+    "Hardcore Techno",
     # 130–139
-    "Terror", "Indie", "BritPop", "Negerpunk", "Polsk Punk",
-    "Beat", "Christian Gangsta Rap", "Heavy Metal", "Black Metal", "Crossover",
+    "Terror",
+    "Indie",
+    "BritPop",
+    "Negerpunk",
+    "Polsk Punk",
+    "Beat",
+    "Christian Gangsta Rap",
+    "Heavy Metal",
+    "Black Metal",
+    "Crossover",
     # 140–147
-    "Contemporary Christian", "Christian Rock", "Merengue", "Salsa",
-    "Thrash Metal", "Anime", "JPop", "Synthpop",
+    "Contemporary Christian",
+    "Christian Rock",
+    "Merengue",
+    "Salsa",
+    "Thrash Metal",
+    "Anime",
+    "JPop",
+    "Synthpop",
 ]
 _GENRE_LOWER: dict[str, int] = {g.lower(): i for i, g in enumerate(_ID3V1_GENRES)}
 
@@ -218,7 +337,7 @@ def _parse_file_name(base_name: str) -> tuple[int | None, str | None, str | None
     tm = _TRACK_PREFIX_RE.match(base_name)
     if tm:
         track = int(tm.group(1))
-        rest = base_name[tm.end():].strip()
+        rest = base_name[tm.end() :].strip()
     else:
         rest = base_name.strip()
 
@@ -489,7 +608,9 @@ def _write_tags(
             _write_tags_vorbis(filepath, artist, title, album, track, year, genre, cover_bytes)
         else:
             _write_tags_mp3(filepath, artist, title, album, track, year, genre, cover_bytes)
-        log.logger.info("Tags written: %s | artist=%s title=%s album=%s track=%s year=%s genre=%s", filepath, artist, title, album, track, year, genre)
+        log.logger.info(
+            "Tags written: %s | artist=%s title=%s album=%s track=%s year=%s genre=%s", filepath, artist, title, album, track, year, genre
+        )
     except Exception as e:
         log.logger.error("Failed to write tags for %s: %s", filepath, str(e))
 
@@ -698,7 +819,14 @@ def _process_file(
 
     log.logger.info(
         "File: %s  artist=%s  title=%s  album=%s  track=%s  year=%s  genre=%s  date=%s",
-        base, artist, title, album, track, year, genre, release_date,
+        base,
+        artist,
+        title,
+        album,
+        track,
+        year,
+        genre,
+        release_date,
     )
 
     if dry_run:

--- a/mediatools/audio_normalize.py
+++ b/mediatools/audio_normalize.py
@@ -459,7 +459,8 @@ def _resize_image(image_bytes: bytes, max_size: int = _MAX_COVER_SIZE) -> bytes:
     try:
         img = PilImage.open(io.BytesIO(image_bytes))
         if img.width > max_size or img.height > max_size:
-            img.thumbnail((max_size, max_size), PilImage.LANCZOS)
+            resample = getattr(PilImage, "Resampling", PilImage).LANCZOS
+            img.thumbnail((max_size, max_size), resample)
         buf = io.BytesIO()
         img.save(buf, format="JPEG", quality=90)
         return buf.getvalue()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pywin32",
     "musicbrainzngs",
     "mutagen",
-    "Pillow",
+    "Pillow>=10.3.0",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pywin32",
     "musicbrainzngs",
     "mutagen",
+    "Pillow",
 ]
 
 classifiers = [
@@ -84,6 +85,7 @@ audio-concat     = "mediatools.audioconcat:main"
 audio-speed      = "mediatools.audiospeed:main"
 video-enhance    = "mediatools.video_enhance:main"
 fix-mp3-meta     = "mediatools.fix_mp3_meta:main"
+audio-normalize  = "mediatools.audio_normalize:main"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0", "wheel", "twine"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ exifread
 librosa
 musicbrainzngs
 mutagen
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ exifread
 librosa
 musicbrainzngs
 mutagen
-Pillow
+Pillow>=10.3.0 # not directly required, pinned to avoid known CVEs

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
         "librosa",
         "musicbrainzngs",
         "mutagen",
-        "Pillow",
+        "Pillow>=10.3.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setuptools.setup(
         "librosa",
         "musicbrainzngs",
         "mutagen",
+        "Pillow",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -97,6 +98,7 @@ setuptools.setup(
             "audio-speed = mediatools.audiospeed:main",
             "video-enhance = mediatools.video_enhance:main",
             "fix-mp3-meta = mediatools.fix_mp3_meta:main",
+            "audio-normalize = mediatools.audio_normalize:main",
         ]
     },
     python_requires=">=3.10",

--- a/tests/test_audio_normalize.py
+++ b/tests/test_audio_normalize.py
@@ -1,0 +1,612 @@
+#!python3
+#
+# media-tools
+# Copyright (C) 2019-2024 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""Tests for mediatools.audio_normalize"""
+
+import datetime
+import os
+import shutil
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mutagen.id3 import ID3, TIT2, TPE1, TALB, TRCK, TDRC
+
+import mediatools.audio_normalize as norm
+
+FIXTURE_MP3 = os.path.join("it", "seal.mp3")
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_genre_exact():
+    assert norm._find_genre("Rock") == "Rock"
+    assert norm._find_genre("rock") == "Rock"
+    assert norm._find_genre("BLUES") == "Blues"
+
+
+def test_find_genre_fuzzy():
+    assert norm._find_genre("Jazz") == "Jazz"
+    assert norm._find_genre("Classic") == "Classic Rock"
+
+
+def test_find_genre_unknown():
+    assert norm._find_genre("XYZ_NotAGenre_12345") is None
+    assert norm._find_genre("") is None
+    assert norm._find_genre(None) is None
+
+
+def test_find_genre_winamp():
+    assert norm._find_genre("Folk") == "Folk"
+    assert norm._find_genre("Synthpop") == "Synthpop"
+    assert norm._find_genre("Indie") == "Indie"
+
+
+def test_strip_encoding_postfix():
+    assert norm._strip_encoding_postfix("Song (128kbit_AAC)") == "Song"
+    assert norm._strip_encoding_postfix("Track [320kbps MP3]") == "Track"
+    assert norm._strip_encoding_postfix("Normal Title") == "Normal Title"
+    assert norm._strip_encoding_postfix("Song (256kb)") == "Song"
+
+
+def test_strip_exotic_unicode():
+    assert norm._strip_exotic_unicode("Café") == "Cafe"
+    assert norm._strip_exotic_unicode("Björk") == "Bjork"
+    assert norm._strip_exotic_unicode("Normal") == "Normal"
+    assert norm._strip_exotic_unicode("über") == "uber"
+
+
+def test_clean_basename():
+    assert norm._clean_basename("Song (128kbit_AAC)") == "Song"
+    assert norm._clean_basename("Café (320kbps MP3)") == "Cafe"
+    assert norm._clean_basename("Normal Title") == "Normal Title"
+
+
+def test_title_case():
+    assert norm._title_case("hello world") == "Hello World"
+    assert norm._title_case("") == ""
+    assert norm._title_case("the BEATLES") == "The Beatles"
+
+
+def test_sentence_case():
+    assert norm._sentence_case("HELLO WORLD") == "Hello world"
+    assert norm._sentence_case("") == ""
+    assert norm._sentence_case("come together") == "Come together"
+
+
+def test_parse_dir_name_artist_album_year():
+    artist, album, year = norm._parse_dir_name("The Beatles - Abbey Road (1969)")
+    assert artist == "The Beatles"
+    assert album == "Abbey Road"
+    assert year == 1969
+
+
+def test_parse_dir_name_artist_album_no_year():
+    artist, album, year = norm._parse_dir_name("Pink Floyd - The Wall")
+    assert artist == "Pink Floyd"
+    assert album == "The Wall"
+    assert year is None
+
+
+def test_parse_dir_name_artist_only():
+    artist, album, year = norm._parse_dir_name("Radiohead")
+    assert artist == "Radiohead"
+    assert album is None
+    assert year is None
+
+
+def test_parse_file_name_track_artist_title():
+    track, artist, title = norm._parse_file_name("01 - The Beatles - Come Together")
+    assert track == 1
+    assert artist == "The Beatles"
+    assert title == "Come together"
+
+
+def test_parse_file_name_track_title():
+    track, artist, title = norm._parse_file_name("03. Blackbird")
+    assert track == 3
+    assert artist is None
+    assert title == "Blackbird"
+
+
+def test_parse_file_name_no_track():
+    track, artist, title = norm._parse_file_name("Artist - Song Title")
+    assert track is None
+    assert artist == "Artist"
+    assert title == "Song title"
+
+
+def test_parse_file_name_track_only():
+    track, artist, title = norm._parse_file_name("01")
+    assert track == 1
+    assert title is None
+
+
+def test_parse_mb_date_full():
+    year, date = norm._parse_mb_date("1969-09-26")
+    assert year == 1969
+    assert date == datetime.date(1969, 9, 26)
+
+
+def test_parse_mb_date_year_month():
+    year, date = norm._parse_mb_date("1973-03")
+    assert year == 1973
+    assert date == datetime.date(1973, 3, 1)
+
+
+def test_parse_mb_date_year_only():
+    year, date = norm._parse_mb_date("1994")
+    assert year == 1994
+    assert date == datetime.date(1994, 1, 1)
+
+
+def test_parse_mb_date_empty():
+    year, date = norm._parse_mb_date("")
+    assert year is None
+    assert date is None
+
+
+def test_parse_mb_date_invalid():
+    year, date = norm._parse_mb_date("not-a-date")
+    assert year is None
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz mock tests
+# ---------------------------------------------------------------------------
+
+
+def _mb_release_result(date="1994-10-03", genre="Rock"):
+    return {
+        "release-list": [
+            {
+                "id": "release-id-123",
+                "date": date,
+            }
+        ]
+    }
+
+
+def _mb_full_release(date="1994-10-03", genre="Rock"):
+    return {
+        "release": {
+            "date": date,
+            "genre-list": [{"name": genre}],
+            "tag-list": [],
+            "medium-list": [
+                {
+                    "track-list": [
+                        {"recording": {"title": "Track One"}},
+                        {"recording": {"title": "Track Two"}},
+                    ]
+                }
+            ],
+        }
+    }
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.get_release_by_id")
+@patch("mediatools.audio_normalize.musicbrainzngs.search_releases")
+def test_mb_lookup_release_success(mock_search, mock_get):
+    mock_search.return_value = _mb_release_result()
+    mock_get.return_value = _mb_full_release()
+    year, date, genre, tracks, release_id = norm._mb_lookup_release("Seal", "Seal")
+    assert year == 1994
+    assert date == datetime.date(1994, 10, 3)
+    assert genre == "Rock"
+    assert tracks == ["Track One", "Track Two"]
+    assert release_id == "release-id-123"
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_releases")
+def test_mb_lookup_release_no_results(mock_search):
+    mock_search.return_value = {"release-list": []}
+    year, date, genre, tracks, release_id = norm._mb_lookup_release("Unknown", "Unknown")
+    assert year is None
+    assert tracks == []
+    assert release_id is None
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_releases")
+def test_mb_lookup_release_empty_artist(mock_search):
+    year, date, genre, tracks, release_id = norm._mb_lookup_release("", "Album")
+    mock_search.assert_not_called()
+    assert year is None
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_releases")
+def test_mb_lookup_release_exception(mock_search):
+    mock_search.side_effect = Exception("Network error")
+    year, date, genre, tracks, release_id = norm._mb_lookup_release("Artist", "Album")
+    assert year is None
+    assert tracks == []
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_recordings")
+def test_mb_lookup_track_success(mock_search):
+    mock_search.return_value = {
+        "recording-list": [
+            {"release-list": [{"date": "1994-10-03"}]}
+        ]
+    }
+    year, date = norm._mb_lookup_track("Seal", "Crazy")
+    assert year == 1994
+    assert date == datetime.date(1994, 10, 3)
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_recordings")
+def test_mb_lookup_track_no_date(mock_search):
+    mock_search.return_value = {"recording-list": [{"release-list": [{"date": ""}]}]}
+    year, date = norm._mb_lookup_track("Seal", "Crazy")
+    assert year is None
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_recordings")
+def test_mb_lookup_track_empty(mock_search):
+    year, date = norm._mb_lookup_track("", "")
+    mock_search.assert_not_called()
+    assert year is None
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.search_recordings")
+def test_mb_lookup_track_exception(mock_search):
+    mock_search.side_effect = Exception("error")
+    year, date = norm._mb_lookup_track("Artist", "Title")
+    assert year is None
+
+
+# ---------------------------------------------------------------------------
+# Cover art tests
+# ---------------------------------------------------------------------------
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.get_image_front")
+def test_fetch_cover_art_success(mock_get):
+    mock_get.return_value = b"JPEG_DATA"
+    data = norm._fetch_cover_art("release-123")
+    assert data == b"JPEG_DATA"
+
+
+@patch("mediatools.audio_normalize.musicbrainzngs.get_image_front")
+def test_fetch_cover_art_exception(mock_get):
+    mock_get.side_effect = Exception("Not found")
+    data = norm._fetch_cover_art("release-123")
+    assert data is None
+
+
+def test_fetch_cover_art_no_id():
+    data = norm._fetch_cover_art("")
+    assert data is None
+
+
+def test_resize_image_no_pillow():
+    original = b"FAKE_IMAGE"
+    with patch.object(norm, "_PIL_AVAILABLE", False):
+        result = norm._resize_image(original)
+    assert result == original
+
+
+def test_save_cover_to_folder(tmp_path):
+    fake_image = b"FAKE_IMAGE_DATA"
+    with patch("mediatools.audio_normalize._resize_image", return_value=fake_image):
+        norm._save_cover_to_folder(str(tmp_path), fake_image)
+    assert os.path.exists(tmp_path / "folder.jpg")
+
+
+def test_save_cover_to_folder_error(tmp_path):
+    with patch("mediatools.audio_normalize._resize_image", side_effect=Exception("err")):
+        norm._save_cover_to_folder(str(tmp_path), b"data")
+
+
+# ---------------------------------------------------------------------------
+# Tag read/write tests (using real MP3 fixture)
+# ---------------------------------------------------------------------------
+
+
+def test_read_existing_tags_mp3(tmp_path):
+    dest = str(tmp_path / "seal.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    artist, title, album, track, year, genre = norm._read_existing_tags(dest)
+    assert artist is not None or True  # just check it doesn't crash
+
+
+def test_read_existing_tags_missing_file():
+    artist, title, album, track, year, genre = norm._read_existing_tags("/nonexistent/file.mp3")
+    assert artist is None
+    assert title is None
+
+
+def test_read_existing_tags_m4a():
+    mock_mp4 = MagicMock()
+    mock_mp4.tags = {
+        "©ART": ["Test Artist"],
+        "©nam": ["Test Title"],
+        "©alb": ["Test Album"],
+        "trkn": [(2, 0)],
+        "©day": ["2001"],
+        "©gen": ["Rock"],
+    }
+    with patch("mediatools.audio_normalize.MP4", return_value=mock_mp4):
+        artist, title, album, track, year, genre = norm._read_existing_tags("song.m4a")
+    assert artist == "Test Artist"
+    assert title == "Test Title"
+    assert album == "Test Album"
+    assert track == 2
+    assert year == 2001
+    assert genre == "Rock"
+
+
+def test_read_existing_tags_m4a_no_tags():
+    mock_mp4 = MagicMock()
+    mock_mp4.tags = {}
+    with patch("mediatools.audio_normalize.MP4", return_value=mock_mp4):
+        artist, title, album, track, year, genre = norm._read_existing_tags("song.m4a")
+    assert artist is None
+
+
+def test_write_tags_mp3(tmp_path):
+    dest = str(tmp_path / "seal.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    with patch("mediatools.audio_normalize.os.utime"):
+        norm._write_tags(dest, "Seal", "Crazy", "Seal", 1, 1994, "Rock", None)
+    tags = ID3(dest)
+    assert str(tags["TPE1"]) == "Seal"
+    assert str(tags["TIT2"]) == "Crazy"
+    assert str(tags["TCON"]) == "Rock"
+
+
+def test_write_tags_mp3_with_cover(tmp_path):
+    dest = str(tmp_path / "seal.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    norm._write_tags(dest, "Seal", "Crazy", "Seal", 1, 1994, "Rock", b"\xff\xd8\xff")
+    tags = ID3(dest)
+    assert any(k.startswith("APIC") for k in tags)
+
+
+def test_write_tags_m4a():
+    mock_mp4 = MagicMock()
+    mock_mp4.tags = {}
+    with patch("mediatools.audio_normalize.MP4", return_value=mock_mp4):
+        norm._write_tags("song.m4a", "Artist", "Title", "Album", 1, 2000, "Rock", None)
+    assert mock_mp4.save.called
+
+
+def test_write_tags_m4a_with_cover():
+    mock_mp4 = MagicMock()
+    mock_mp4.tags = {}
+    with patch("mediatools.audio_normalize.MP4", return_value=mock_mp4):
+        norm._write_tags("song.m4a", "Artist", "Title", "Album", 1, 2000, "Pop", b"\xff\xd8\xff")
+    assert "covr" in mock_mp4.tags
+
+
+def test_write_tags_vorbis_ogg():
+    mock_audio = MagicMock()
+    mock_audio.tags = {}
+    mock_audio.__class__ = MagicMock  # not FLAC
+    with patch("mediatools.audio_normalize.mutagen.File", return_value=mock_audio):
+        norm._write_tags("song.ogg", "Artist", "Title", "Album", 2, 2005, "Folk", None)
+    assert mock_audio.save.called
+
+
+def test_write_tags_vorbis_none_file():
+    with patch("mediatools.audio_normalize.mutagen.File", return_value=None):
+        norm._write_tags("song.ogg", "Artist", "Title", "Album", 1, 2000, None, None)
+
+
+def test_write_tags_exception(tmp_path):
+    norm._write_tags("/nonexistent/song.mp3", "Artist", "Title", "Album", 1, 2000, None, None)
+
+
+# ---------------------------------------------------------------------------
+# File timestamp and rename tests
+# ---------------------------------------------------------------------------
+
+
+def test_set_file_date(tmp_path):
+    f = tmp_path / "test.mp3"
+    f.write_bytes(b"data")
+    norm._set_file_date(str(f), datetime.date(1994, 10, 3))
+    stat = os.stat(str(f))
+    dt = datetime.datetime.fromtimestamp(stat.st_mtime)
+    assert dt.year == 1994
+    assert dt.month == 10
+    assert dt.day == 3
+
+
+def test_set_file_date_error():
+    norm._set_file_date("/nonexistent/file.mp3", datetime.date(2000, 1, 1))
+
+
+def test_rename_file(tmp_path):
+    src = tmp_path / "old name.mp3"
+    src.write_bytes(b"data")
+    new_path = norm._rename_file(str(src), "new name")
+    assert os.path.exists(new_path)
+    assert "new name.mp3" in new_path
+
+
+def test_rename_file_same_name(tmp_path):
+    src = tmp_path / "same.mp3"
+    src.write_bytes(b"data")
+    result = norm._rename_file(str(src), "same")
+    assert result == str(src)
+
+
+def test_rename_file_error(tmp_path):
+    src = tmp_path / "test.mp3"
+    src.write_bytes(b"data")
+    with patch("mediatools.audio_normalize.os.rename", side_effect=OSError("denied")):
+        result = norm._rename_file(str(src), "other")
+    assert result == str(src)
+
+
+# ---------------------------------------------------------------------------
+# _process_file integration tests
+# ---------------------------------------------------------------------------
+
+
+@patch("mediatools.audio_normalize._write_tags")
+@patch("mediatools.audio_normalize._set_file_date")
+def test_process_file_dry_run(mock_date, mock_write, tmp_path):
+    dest = str(tmp_path / "01 - Seal - Crazy.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    norm._process_file(dest, "Seal", "Seal", 1994, datetime.date(1994, 10, 3), "Rock", [], None, dry_run=True)
+    mock_write.assert_not_called()
+    mock_date.assert_not_called()
+
+
+@patch("mediatools.audio_normalize._set_file_date")
+@patch("mediatools.audio_normalize._write_tags")
+def test_process_file_writes_tags(mock_write, mock_date, tmp_path):
+    dest = str(tmp_path / "01 - Seal - Crazy.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    norm._process_file(dest, "Seal", "Seal", 1994, datetime.date(1994, 10, 3), "Rock", [], None, dry_run=False)
+    mock_write.assert_called_once()
+    mock_date.assert_called_once()
+
+
+@patch("mediatools.audio_normalize._mb_lookup_track", return_value=(1991, datetime.date(1991, 1, 1)))
+@patch("mediatools.audio_normalize._write_tags")
+@patch("mediatools.audio_normalize._set_file_date")
+def test_process_file_mb_track_lookup(mock_date, mock_write, mock_track, tmp_path):
+    dest = str(tmp_path / "Artist - Title.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    tags = ID3(dest)
+    tags.delall("TDRC")
+    tags.save(dest)
+    norm._process_file(dest, None, None, None, None, None, [], None, dry_run=False)
+    mock_track.assert_called()
+
+
+@patch("mediatools.audio_normalize._write_tags")
+@patch("mediatools.audio_normalize._set_file_date")
+def test_process_file_mb_tracks_title(mock_date, mock_write, tmp_path):
+    dest = str(tmp_path / "03.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    tags = ID3(dest)
+    tags.delall("TIT2")
+    tags.delall("TRCK")
+    tags.save(dest)
+    mb_tracks = ["Track One", "Track Two", "Wild"]
+    norm._process_file(dest, "Seal", "Seal", 1994, None, None, mb_tracks, None, dry_run=False)
+    _, call_kwargs = mock_write.call_args
+    # title comes from mb_tracks[2] (track 3 → index 2)
+
+
+@patch("mediatools.audio_normalize._write_tags")
+@patch("mediatools.audio_normalize._set_file_date")
+def test_process_file_renames_dirty_filename(mock_date, mock_write, tmp_path):
+    dest = str(tmp_path / "Song (128kbit_AAC).mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    norm._process_file(dest, "Artist", "Album", 2000, None, None, [], None, dry_run=False)
+    assert os.path.exists(str(tmp_path / "Song.mp3"))
+
+
+# ---------------------------------------------------------------------------
+# _process_directory tests
+# ---------------------------------------------------------------------------
+
+
+@patch("mediatools.audio_normalize._fetch_cover_art", return_value=None)
+@patch("mediatools.audio_normalize._mb_lookup_release", return_value=(1994, datetime.date(1994, 10, 3), "Rock", ["Crazy", "Newborn"], "rel-123"))
+@patch("mediatools.audio_normalize._process_file")
+def test_process_directory(mock_pf, mock_mb, mock_cover, tmp_path):
+    shutil.copy(FIXTURE_MP3, str(tmp_path / "01 - Seal - Crazy.mp3"))
+    (tmp_path / "notes.txt").write_text("ignore me")
+    norm._process_directory(str(tmp_path), dry_run=False)
+    mock_pf.assert_called()
+
+
+@patch("mediatools.audio_normalize._fetch_cover_art", return_value=b"JPEG_DATA")
+@patch("mediatools.audio_normalize._save_cover_to_folder")
+@patch("mediatools.audio_normalize._mb_lookup_release", return_value=(1994, datetime.date(1994, 10, 3), "Rock", [], "rel-123"))
+@patch("mediatools.audio_normalize._process_file")
+def test_process_directory_saves_cover(mock_pf, mock_mb, mock_save, mock_cover, tmp_path):
+    album_dir = tmp_path / "Seal - Seal"
+    album_dir.mkdir()
+    shutil.copy(FIXTURE_MP3, str(album_dir / "01.mp3"))
+    norm._process_directory(str(album_dir), dry_run=False)
+    mock_save.assert_called_once()
+
+
+@patch("mediatools.audio_normalize._fetch_cover_art", return_value=b"JPEG_DATA")
+@patch("mediatools.audio_normalize._save_cover_to_folder")
+@patch("mediatools.audio_normalize._mb_lookup_release", return_value=(1994, datetime.date(1994, 10, 3), "Rock", [], "rel-123"))
+@patch("mediatools.audio_normalize._process_file")
+def test_process_directory_skip_cover_if_exists(mock_pf, mock_mb, mock_save, mock_cover, tmp_path):
+    album_dir = tmp_path / "Seal - Seal"
+    album_dir.mkdir()
+    shutil.copy(FIXTURE_MP3, str(album_dir / "01.mp3"))
+    (album_dir / "folder.jpg").write_bytes(b"existing")
+    norm._process_directory(str(album_dir), dry_run=False)
+    mock_save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+
+@patch("mediatools.audio_normalize._process_directory")
+def test_main_default_dir(mock_pd):
+    with patch("sys.argv", ["audio-normalize"]):
+        with patch("os.path.isdir", return_value=True):
+            with patch("os.listdir", return_value=[]):
+                with pytest.raises(SystemExit):
+                    norm.main()
+
+
+@patch("mediatools.audio_normalize._process_directory")
+def test_main_dry_run(mock_pd, tmp_path):
+    with patch("sys.argv", ["audio-normalize", "-f", str(tmp_path), "--dry-run"]):
+        with patch("os.listdir", return_value=[]):
+            with pytest.raises(SystemExit):
+                norm.main()
+
+
+@patch("mediatools.audio_normalize._process_file")
+@patch("mediatools.audio_normalize._mb_lookup_release", return_value=(None, None, None, [], None))
+@patch("mediatools.audio_normalize._fetch_cover_art", return_value=None)
+def test_main_with_mp3_file(mock_cover, mock_mb, mock_pf, tmp_path):
+    dest = str(tmp_path / "seal.mp3")
+    shutil.copy(FIXTURE_MP3, dest)
+    with patch("sys.argv", ["audio-normalize", "-f", dest]):
+        with pytest.raises(SystemExit):
+            norm.main()
+    mock_pf.assert_called()
+
+
+def test_main_non_audio_file(tmp_path):
+    f = str(tmp_path / "notes.txt")
+    open(f, "w").close()
+    with patch("sys.argv", ["audio-normalize", "-f", f]):
+        with pytest.raises(SystemExit):
+            norm.main()
+
+
+def test_main_debug_flag(tmp_path):
+    with patch("sys.argv", ["audio-normalize", "-f", str(tmp_path), "-g", "2"]):
+        with patch("os.listdir", return_value=[]):
+            with pytest.raises(SystemExit):
+                norm.main()


### PR DESCRIPTION
## Summary
- New `audio_normalize.py` CLI tool extending `fix_mp3_meta` with:
  - Exact release date from MusicBrainz (YYYY-MM-DD when available)
  - Genre encoding using ID3v1 genres (0–79) + Winamp extensions (80–147)
  - Album art fetched from MusicBrainz Cover Art Archive and embedded in audio files
  - `folder.jpg` saved (max 600×600 via Pillow) for album directories
  - Multi-format tag writing: MP3 (ID3v1.1+ID3v2.3), M4A, OGG, OPUS, FLAC
  - Filename cleanup: strip encoding postfixes and exotic Unicode characters
- Batch wrapper `batch-files-audio/audio normalize.bat`
- Added `Pillow` dependency to `requirements.txt`, `setup.py`, `pyproject.toml`
- Registered `audio-normalize` console entry point

## Test plan
- [ ] CI passes
- [ ] `audio-normalize -f <album_dir>` writes tags, cover art, and sets timestamps
- [ ] `audio-normalize --dry-run` logs without modifying files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)