### PR TITLE
Fix ruff linting not reported in CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ruff
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           sudo apt update
           sudo apt install ffmpeg

--- a/filters/fader.py
+++ b/filters/fader.py
@@ -1,1 +1,20 @@
-
+#
+# media-tools
+# Copyright (C) 2019-2024 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+"""Fader filter - placeholder for future fade in/out audio/video filter implementation."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flake8
 pylint
 bandit
+ruff
 pytest
 coverage
 jprops

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.python.version=3.6
 sonar.python.flake8.reportPaths=build/flake8-report.out
 sonar.python.pylint.reportPaths=build/pylint-report.out
 sonar.python.bandit.reportPaths=build/bandit-report.json
-# sonar.externalIssuesReportPaths=build/ruff-report.json
+sonar.externalIssuesReportPaths=build/ruff-report.json
 sonar.python.coverage.reportPaths=build/coverage.xml
 sonar.python.xunit.reportPath=build/ut.xml
 #, tests_windows/coverage_windows.xml


### PR DESCRIPTION
## Summary
- Uncomment `sonar.externalIssuesReportPaths` in `sonar-project.properties` so ruff findings are sent to SonarCloud
- Add `ruff` to `requirements.txt` as a declared dev dependency alongside pylint/flake8/bandit
- Remove redundant explicit `pip install ruff` from `build.yml` (now covered by `requirements.txt`)

## Test plan
- [ ] CI pipeline runs ruff via `run_linters.sh`
- [ ] SonarCloud scan picks up `build/ruff-report.json` and shows ruff issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)