### PR TITLE
Fix video-crop passing file list instead of filename (fixes #258)

### DIFF
--- a/mediatools/crop.py
+++ b/mediatools/crop.py
@@ -41,7 +41,7 @@ def main():
 
     kwargs["width"], kwargs["height"] = kwargs["box"].split("x", maxsplit=2)
     log.logger.debug("KW=%s", str(kwargs))
-    outputfile = creator.file(kwargs["inputfiles"]).crop(out_file=kwargs.get("outputfile", None), **kwargs)
+    outputfile = creator.file(kwargs.pop("inputfiles")[0]).crop(out_file=kwargs.get("outputfile", None), **kwargs)
     log.logger.info("Generated %s", outputfile)
     print("Generated {}".format(outputfile))
 


### PR DESCRIPTION
## Summary
- `mediatools/crop.py` passed the raw `inputfiles` list (from `nargs=\"+\"`) to `creator.file()`, which expects a single filename string, causing a `TypeError` before ffmpeg ever ran (`crop ffmpeg cmd line is broken`, #258)
- Fixed by using `kwargs.pop("inputfiles")[0]`, matching the convention used by every other single-file CLI tool (speed.py, volume.py, reverse.py, etc.)

## Test plan
- [x] `python -m mediatools.crop -i it/video-1920x1080.mp4 -o out.mp4 --box 320x240 --position center` runs ffmpeg successfully and produces a correctly cropped output
- [x] `pytest tests/test_video.py -k crop` passes

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)